### PR TITLE
Add drip account id settings page & api endpoint

### DIFF
--- a/devtools_wp/Dockerfile
+++ b/devtools_wp/Dockerfile
@@ -1,6 +1,6 @@
 FROM wordpress:5.3.1-php7.2-apache
 
 RUN curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o /usr/local/bin/wp && chmod +x /usr/local/bin/wp
-RUN apt-get update && apt-get install -y less unzip
+RUN apt-get update && apt-get install -y less unzip vim wget
 
 RUN curl https://downloads.wordpress.org/plugin/woocommerce.3.8.1.zip -o /usr/src/woocommerce.zip && cd /usr/src/wordpress/wp-content/plugins && unzip /usr/src/woocommerce.zip

--- a/devtools_wp/install-composer.sh
+++ b/devtools_wp/install-composer.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/drip-woocommerce-settings.php
+++ b/drip-woocommerce-settings.php
@@ -93,7 +93,7 @@ class WC_Settings_Drip {
         'id'   => self::ACCOUNT_ID_KEY,
         'name' => __( 'Account ID', self::NAME ),
         'type' => 'number',
-        'desc' => __( 'Drip Account ID', self::NAME ),
+        'desc' => __( 'Read-only, visible if integration was successful', self::NAME ),
         'custom_attributes' => array('readonly' => 'readonly'),
       ),
       'section_end' => array(

--- a/drip-woocommerce-settings.php
+++ b/drip-woocommerce-settings.php
@@ -1,0 +1,109 @@
+<?php
+class WC_Settings_Drip {
+  const NAME = "woocommerce-settings-drip";
+  const ACCOUNT_ID_KEY = "account_id";
+
+  /**
+   * Bootstraps the class and hooks required actions & filters.
+   *
+   */
+  public static function init() {
+    add_filter( 'woocommerce_settings_tabs_array', __CLASS__ . '::add_settings_tab', 50 );
+    add_action( 'woocommerce_settings_tabs_settings_drip', __CLASS__ . '::settings_tab' );
+    //add_action( 'woocommerce_update_options_settings_drip', __CLASS__ . '::update_settings' );
+    add_filter( 'woocommerce_settings_groups', __CLASS__ . '::settings_group');
+    add_filter( 'woocommerce_settings-drip', __CLASS__ . '::settings_group_options');
+  }
+
+
+  /**
+   * Add a new settings tab to the WooCommerce settings tabs array.
+   *
+   * @param array $settings_tabs Array of WooCommerce setting tabs & their labels, excluding the Subscription tab.
+   * @return array $settings_tabs Array of WooCommerce setting tabs & their labels, including the Subscription tab.
+   */
+  public static function add_settings_tab( $settings_tabs ) {
+    $settings_tabs['settings_drip'] = __( 'Drip', self::NAME );
+    return $settings_tabs;
+  }
+
+
+  /**
+   * Uses the WooCommerce admin fields API to output settings via the @see woocommerce_admin_fields() function.
+   *
+   * @uses woocommerce_admin_fields()
+   * @uses self::get_settings()
+   */
+  public static function settings_tab() {
+    woocommerce_admin_fields( self::get_settings() );
+  }
+
+
+  /**
+   * Uses the WooCommerce options API to save settings via the @see woocommerce_update_options() function.
+   *
+   * @uses woocommerce_update_options()
+   * @uses self::get_settings()
+   */
+  public static function update_settings() {
+    woocommerce_update_options( self::get_settings() );
+  }
+
+  /**
+   * Register the `drip` settings group.
+   */
+  public static function settings_group( $locations ) {
+    $locations[] = array(
+      'id'          => 'drip',
+      'label'       => __( 'Drip', 'woocommerce' ),
+      'description' => __( 'Drip Settings', 'woocommerce' ),
+    );
+    return $locations;
+  }
+
+  /**
+   * Register options under `drip` settings group.
+   */
+  public static function settings_group_options( $settings ) {
+    $settings[] = array(
+      'id'          => self::ACCOUNT_ID_KEY,
+      'option_key'  => self::ACCOUNT_ID_KEY,
+      'label'       => __( 'Account ID', self::NAME ),
+      'description' => __( 'Drip Account ID', self::NAME ),
+      'default'     => '',
+      'type'        => 'number',
+    );
+    return $settings;
+  }
+
+  /**
+   * Get all the settings for this plugin for @see woocommerce_admin_fields() function.
+   *
+   * @return array Array of settings for @see woocommerce_admin_fields() function.
+   */
+  public static function get_settings() {
+    $settings = array(
+      'section_title' => array(
+        'id'   => 'wc_settings_drip_section_title',
+        'name' => __( 'Drip', self::NAME ),
+        'type' => 'title',
+        'desc' => '',
+      ),
+      self::ACCOUNT_ID_KEY => array(
+        'id'   => self::ACCOUNT_ID_KEY,
+        'name' => __( 'Account ID', self::NAME ),
+        'type' => 'number',
+        'desc' => __( 'Drip Account ID', self::NAME ),
+        'custom_attributes' => array('readonly' => 'readonly'),
+      ),
+      'section_end' => array(
+        'type' => 'sectionend',
+        'id'   => 'wc_settings_drip_section_end'
+      )
+    );
+
+    return apply_filters( 'wc_settings_drip_settings', $settings );
+  }
+}
+
+WC_Settings_Drip::init();

--- a/drip-woocommerce-settings.php
+++ b/drip-woocommerce-settings.php
@@ -55,8 +55,8 @@ class WC_Settings_Drip {
   public static function settings_group( $locations ) {
     $locations[] = array(
       'id'          => 'drip',
-      'label'       => __( 'Drip', 'woocommerce' ),
-      'description' => __( 'Drip Settings', 'woocommerce' ),
+      'label'       => __( 'Drip', self::NAME ),
+      'description' => __( 'Drip Settings', self::NAME ),
     );
     return $locations;
   }

--- a/drip-woocommerce.php
+++ b/drip-woocommerce.php
@@ -52,7 +52,7 @@ class drip_woocommerce_cart_events
                 );
             }
         }
-        
+
         do_action( 'wc_drip_woocommerce_cart_event', $event_data );
     }
 
@@ -85,3 +85,5 @@ class drip_woocommerce_cart_events
         return $categories;
     }
 }
+
+include('drip-woocommerce-settings.php');


### PR DESCRIPTION
Addresses: https://dripcom.atlassian.net/browse/ECI-363

Note: This adds both `drip/account_id` settings _tab_ (read-only) and api endpoint, and they reference the same underlying data (ie. a change via api will be visible on the settings tab (read-only)).

Update: also used `phpcbf` for format code so it (hopefully) passes CI.