### PR TITLE
Add drip-woocommerce version to webhook headers

### DIFF
--- a/drip-woocommerce.php
+++ b/drip-woocommerce.php
@@ -17,9 +17,11 @@ defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
     require_once(__DIR__ . '/src/class-drip-woocommerce-settings.php');
     require_once(__DIR__ . '/src/class-drip-woocommerce-snippet.php');
-    require_once __DIR__ . '/src/class-drip-woocommerce-cart-events.php';
+    require_once(__DIR__ . '/src/class-drip-woocommerce-cart-events.php');
+    require_once(__DIR__ . '/src/class-drip-woocommerce-version.php');
 
     Drip_Woocommerce_Settings::init();
     Drip_Woocommerce_Snippet::init();
     Drip_Woocommerce_Cart_Events::init();
+    Drip_Woocommerce_Version::init();
 }

--- a/src/class-drip-woocommerce-version.php
+++ b/src/class-drip-woocommerce-version.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once( ABSPATH . "wp-admin/includes/plugin.php" );
+
+class Drip_Woocommerce_Version {
+  const HEADER = "X-WC-Drip-Version";
+
+  public static function init() {
+    add_filter( "woocommerce_webhook_http_args", __CLASS__ . "::add_version_header", 50 );
+  }
+
+  public static function add_version_header( $http_args ) {
+    // TODO: Is it possible to only set this for webhooks destined to drip?
+    // if $webhook->get_name() contains 'Drip', perhaps?
+    if ( $version = self::my_plugin_data( "Version" ) ) {
+      $http_args["headers"][self::HEADER] = $version;
+    }
+    return $http_args;
+  }
+
+  private static function my_plugin_data( $attribute ) {
+    $path = realpath(__DIR__ . "/../drip-woocommerce.php");
+    $plugin_data = get_plugin_data( $path );
+    return trim($plugin_data[$attribute]);
+  }
+}

--- a/src/class-drip-woocommerce-version.php
+++ b/src/class-drip-woocommerce-version.php
@@ -6,14 +6,16 @@ class Drip_Woocommerce_Version {
   const HEADER = "X-WC-Drip-Version";
 
   public static function init() {
-    add_filter( "woocommerce_webhook_http_args", __CLASS__ . "::add_version_header", 50 );
+    add_filter( "woocommerce_webhook_http_args", __CLASS__ . "::add_version_header", 50, 3 );
   }
 
-  public static function add_version_header( $http_args ) {
-    // TODO: Is it possible to only set this for webhooks destined to drip?
-    // if $webhook->get_name() contains 'Drip', perhaps?
-    if ( $version = self::my_plugin_data( "Version" ) ) {
-      $http_args["headers"][self::HEADER] = $version;
+  public static function add_version_header( $http_args, $_arg, $this_id ) {
+    // $this_id is webhook id
+    $webhook_name = (new WC_Webhook($this_id))->get_name();
+    if ( strpos(strtolower($webhook_name), "drip") !== false ) {
+      if ( $version = self::my_plugin_data( "Version" ) ) {
+        $http_args["headers"][self::HEADER] = $version;
+      }
     }
     return $http_args;
   }


### PR DESCRIPTION
Addresses: https://dripcom.atlassian.net/browse/ECI-400

Needs: ~https://github.com/DripEmail/drip-woocommerce/pull/10~

#### Update
Was able to limit modification of headers to webhooks with `drip` in the name. There are a couple issues with this that I can think of:
* Each webhook now has to load the webhook data from the webhook $id. I don't know what the performance implications of this are (if any).
* Drip-related webhook detection is simplistic, it just checks for the word "drip" in the webhook name. The microservice does the same thing when adding and removing webhooks. Nothing stops the customer from renaming these, which would now cause both the plugin and the microservice some problems.

Both of these issues could be addressed if the plugin and microservice tracked webhook ids that were under management. But this would require additional effort, and I'm not sure if it'd be a priority right now.