### PR TITLE
Linter fixes

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -18,7 +18,7 @@
 
 	<!-- Rules: Check PHP version compatibility -->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.6-"/>
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -26,7 +26,10 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
-	<rule ref="WordPress"></rule>
+	<rule ref="WordPress">
+		<!-- We use constants for this, so the sniffer breaks. -->
+		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralDomain" />
+	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/drip.php
+++ b/drip.php
@@ -1,11 +1,14 @@
 <?php
 /**
+ * The starting point for the Drip WooCommerce plugin.
+ *
  * @package Drip_Woocommerce
  */
+
 /*
 Plugin Name: Drip
 Plugin URI: https://github.com/DripEmail/drip-woocommerce
-Description: A Wordpress plugin to connect to Drip's WooCommerce integration
+Description: A WordPress plugin to connect to Drip's WooCommerce integration
 Version: 0.0.1
 Author: DripEmail
 Author URI: https://github.com/DripEmail/
@@ -15,11 +18,11 @@ License: GPLv2
 defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
 if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
-	require_once(__DIR__ . '/src/class-drip-woocommerce-settings.php');
-	require_once(__DIR__ . '/src/class-drip-woocommerce-snippet.php');
-	require_once(__DIR__ . '/src/class-drip-woocommerce-cart-events.php');
-	require_once(__DIR__ . '/src/class-drip-woocommerce-view-events.php');
-	require_once(__DIR__ . '/src/class-drip-woocommerce-version.php');
+	require_once __DIR__ . '/src/class-drip-woocommerce-settings.php';
+	require_once __DIR__ . '/src/class-drip-woocommerce-snippet.php';
+	require_once __DIR__ . '/src/class-drip-woocommerce-cart-events.php';
+	require_once __DIR__ . '/src/class-drip-woocommerce-view-events.php';
+	require_once __DIR__ . '/src/class-drip-woocommerce-version.php';
 
 	Drip_Woocommerce_Settings::init();
 	Drip_Woocommerce_Snippet::init();

--- a/drip.php
+++ b/drip.php
@@ -15,15 +15,15 @@ License: GPLv2
 defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
 if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
-    require_once(__DIR__ . '/src/class-drip-woocommerce-settings.php');
-    require_once(__DIR__ . '/src/class-drip-woocommerce-snippet.php');
-    require_once(__DIR__ . '/src/class-drip-woocommerce-cart-events.php');
-    require_once(__DIR__ . '/src/class-drip-woocommerce-view-events.php');
-    require_once(__DIR__ . '/src/class-drip-woocommerce-version.php');
+	require_once(__DIR__ . '/src/class-drip-woocommerce-settings.php');
+	require_once(__DIR__ . '/src/class-drip-woocommerce-snippet.php');
+	require_once(__DIR__ . '/src/class-drip-woocommerce-cart-events.php');
+	require_once(__DIR__ . '/src/class-drip-woocommerce-view-events.php');
+	require_once(__DIR__ . '/src/class-drip-woocommerce-version.php');
 
-    Drip_Woocommerce_Settings::init();
-    Drip_Woocommerce_Snippet::init();
-    Drip_Woocommerce_Cart_Events::init();
-    Drip_Woocommerce_View_Events::init();
-    Drip_Woocommerce_Version::init();
+	Drip_Woocommerce_Settings::init();
+	Drip_Woocommerce_Snippet::init();
+	Drip_Woocommerce_Cart_Events::init();
+	Drip_Woocommerce_View_Events::init();
+	Drip_Woocommerce_Version::init();
 }

--- a/drip.php
+++ b/drip.php
@@ -17,6 +17,7 @@ License: GPLv2
 
 defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
 	require_once __DIR__ . '/src/class-drip-woocommerce-settings.php';
 	require_once __DIR__ . '/src/class-drip-woocommerce-snippet.php';

--- a/src/class-drip-woocommerce-cart-event-product.php
+++ b/src/class-drip-woocommerce-cart-event-product.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Value object for cart event products
+ *
+ * @package Drip_Woocommerce
+ */
+
+/**
+ * Value object for cart event products
+ */
+class Drip_Woocommerce_Cart_Event_Product {
+	/**
+	 * Product ID
+	 *
+	 * @var string
+	 */
+	public $product_id;
+
+	/**
+	 * Product Variant ID
+	 *
+	 * @var string
+	 */
+	public $product_variant_id;
+
+	/**
+	 * SKU
+	 *
+	 * @var string
+	 */
+	public $sku;
+
+	/**
+	 * Name
+	 *
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * Short Description
+	 *
+	 * @var string
+	 */
+	public $short_description;
+
+	/**
+	 * Price
+	 *
+	 * @var float
+	 */
+	public $price;
+
+	/**
+	 * Taxes
+	 *
+	 * @var float
+	 */
+	public $taxes;
+
+	/**
+	 * Total
+	 *
+	 * @var float
+	 */
+	public $total;
+
+	/**
+	 * Quantity
+	 *
+	 * @var int
+	 */
+	public $quantity;
+
+	/**
+	 * Product URL
+	 *
+	 * @var string
+	 */
+	public $product_url;
+
+	/**
+	 * Image URL
+	 *
+	 * @var string
+	 */
+	public $image_url;
+
+	/**
+	 * Categories
+	 *
+	 * @var array
+	 */
+	public $categories = array();
+}

--- a/src/class-drip-woocommerce-cart-event.php
+++ b/src/class-drip-woocommerce-cart-event.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Value object for cart events
+ *
+ * @package Drip_Woocommerce
+ */
+
+/**
+ * Value object for cart events
+ */
+class Drip_Woocommerce_Cart_Event {
+	/**
+	 * Event action
+	 *
+	 * @var string
+	 */
+	public $event_action;
+
+	/**
+	 * Customer email
+	 *
+	 * @var string
+	 */
+	public $customer_email;
+
+	/**
+	 * Session
+	 *
+	 * @var string
+	 */
+	public $session;
+
+	/**
+	 * Grand total
+	 *
+	 * @var float
+	 */
+	public $grand_total;
+
+	/**
+	 * Total discounts
+	 *
+	 * @var float
+	 */
+	public $total_discounts;
+
+	/**
+	 * Total taxes
+	 *
+	 * @var float
+	 */
+	public $total_taxes;
+
+	/**
+	 * Total fees
+	 *
+	 * @var float
+	 */
+	public $total_fees;
+
+	/**
+	 * Total shipping
+	 *
+	 * @var float
+	 */
+	public $total_shipping;
+
+	/**
+	 * Currency
+	 *
+	 * @var string
+	 */
+	public $currency;
+
+	/**
+	 * Cart data
+	 *
+	 * @var array
+	 */
+	public $cart_data = array();
+}

--- a/src/class-drip-woocommerce-cart-events.php
+++ b/src/class-drip-woocommerce-cart-events.php
@@ -4,152 +4,152 @@ defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
 class Drip_Woocommerce_Cart_Events
 {
-    const CART_SESSION_KEY = "drip_cart_session_id";
-    const CART_UPDATED_ACTION = 'updated';
+	const CART_SESSION_KEY = "drip_cart_session_id";
+	const CART_UPDATED_ACTION = 'updated';
 
-    public static function init()
-    {
-        $cart_events = new Drip_Woocommerce_Cart_Events();
-        $cart_events->setup_cart_actions();
-    }
+	public static function init()
+	{
+		$cart_events = new Drip_Woocommerce_Cart_Events();
+		$cart_events->setup_cart_actions();
+	}
 
-    public function setup_cart_actions()
-    {
-        add_action( 'woocommerce_after_cart_item_quantity_update', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
-        add_action( 'woocommerce_cart_item_removed', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
-        add_action( 'woocommerce_add_to_cart', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
-        add_action( 'woocommerce_cart_item_restored', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
-        add_action( 'woocommerce_cart_emptied', array($this, 'drip_woocommerce_cart_updated'), 10, 0  ); // no way to get this from the UI without plugins
-    }
+	public function setup_cart_actions()
+	{
+		add_action( 'woocommerce_after_cart_item_quantity_update', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
+		add_action( 'woocommerce_cart_item_removed', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
+		add_action( 'woocommerce_add_to_cart', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
+		add_action( 'woocommerce_cart_item_restored', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
+		add_action( 'woocommerce_cart_emptied', array($this, 'drip_woocommerce_cart_updated'), 10, 0  ); // no way to get this from the UI without plugins
+	}
 
-    public function drip_woocommerce_cart_updated() {
-        if( $this->user_invalid() ) { return; }
+	public function drip_woocommerce_cart_updated() {
+		if( $this->user_invalid() ) { return; }
 
-        $event = $this->base_event();
+		$event = $this->base_event();
 
-        $cart_contents = WC()->cart->get_cart();
-        foreach( $cart_contents as $product_id => $cart_item_info ) {
-            $product_event_data = $this->product_event_data($cart_item_info);
-            if($product_event_data) {
-                $event->cart_data[$product_id] = $product_event_data;
-            }
-        }
-        do_action( 'wc_drip_woocommerce_cart_event', base64_encode( json_encode( $event ) ) );
+		$cart_contents = WC()->cart->get_cart();
+		foreach( $cart_contents as $product_id => $cart_item_info ) {
+			$product_event_data = $this->product_event_data($cart_item_info);
+			if($product_event_data) {
+				$event->cart_data[$product_id] = $product_event_data;
+			}
+		}
+		do_action( 'wc_drip_woocommerce_cart_event', base64_encode( json_encode( $event ) ) );
 
-        if(WC()->cart->is_empty()) {
-            $this->remove_drip_cart_session_id();
-        }
-    }
+		if(WC()->cart->is_empty()) {
+			$this->remove_drip_cart_session_id();
+		}
+	}
 
-    private function base_event() {
-        WC()->cart->calculate_totals();
-        
-        $event = new Drip_Woocommerce_Cart_Event();
-        $event->event_action = self::CART_UPDATED_ACTION; // TODO: we can trap cart created events if we have to generate a new cart session id
-        $event->customer_email = wp_get_current_user()->user_email;
-        $event->session = $this->drip_cart_session_id();
-        $event->grand_total = WC()->cart->get_total('drip_woocommerce');
-        $event->total_discounts = WC()->cart->get_discount_total('drip_woocommerce');
-        $event->total_taxes = WC()->cart->get_total_tax('drip_woocommerce');
-        $event->total_fees = WC()->cart->get_fee_total('drip_woocommerce');
-        $event->total_shipping = WC()->cart->get_shipping_total('drip_woocommerce');
-        $event->currency = get_option('woocommerce_currency');
-        return $event;
-    }
+	private function base_event() {
+		WC()->cart->calculate_totals();
 
-    private function product_event_data($cart_item_info) {
-        $product_key = $this->product_key($cart_item_info);
-        $product_data = WC()->product_factory->get_product( $product_key );
+		$event = new Drip_Woocommerce_Cart_Event();
+		$event->event_action = self::CART_UPDATED_ACTION; // TODO: we can trap cart created events if we have to generate a new cart session id
+		$event->customer_email = wp_get_current_user()->user_email;
+		$event->session = $this->drip_cart_session_id();
+		$event->grand_total = WC()->cart->get_total('drip_woocommerce');
+		$event->total_discounts = WC()->cart->get_discount_total('drip_woocommerce');
+		$event->total_taxes = WC()->cart->get_total_tax('drip_woocommerce');
+		$event->total_fees = WC()->cart->get_fee_total('drip_woocommerce');
+		$event->total_shipping = WC()->cart->get_shipping_total('drip_woocommerce');
+		$event->currency = get_option('woocommerce_currency');
+		return $event;
+	}
 
-        if( ! $product_data ) { return false; }
+	private function product_event_data($cart_item_info) {
+		$product_key = $this->product_key($cart_item_info);
+		$product_data = WC()->product_factory->get_product( $product_key );
 
-        $cart_event_product = new Drip_Woocommerce_Cart_Event_Product();
-        $cart_event_product->product_id =$cart_item_info['product_id'];
-        $cart_event_product->product_variant_id = $product_key;
-        $cart_event_product->sku = $product_data->get_sku('drip_woocommerce');
-        $cart_event_product->name = $product_data->get_name('drip_woocommerce');
-        $cart_event_product->short_description = $product_data->get_short_description('drip_woocommerce');
-        $cart_event_product->price = $product_data->get_price('drip_woocommerce');
-        $cart_event_product->taxes = $cart_item_info['line_tax'];
-        $cart_event_product->total = $cart_item_info['line_total'];
-        $cart_event_product->quantity = $cart_item_info['quantity'];
-        $cart_event_product->product_url = $product_data->get_permalink();
-        $cart_event_product->image_url = $product_data->get_image('woocommerce_single', array(), true);
-        $cart_event_product->categories = $this->product_categories($product_data);
+		if( ! $product_data ) { return false; }
 
-        return $cart_event_product;
-    }
+		$cart_event_product = new Drip_Woocommerce_Cart_Event_Product();
+		$cart_event_product->product_id =$cart_item_info['product_id'];
+		$cart_event_product->product_variant_id = $product_key;
+		$cart_event_product->sku = $product_data->get_sku('drip_woocommerce');
+		$cart_event_product->name = $product_data->get_name('drip_woocommerce');
+		$cart_event_product->short_description = $product_data->get_short_description('drip_woocommerce');
+		$cart_event_product->price = $product_data->get_price('drip_woocommerce');
+		$cart_event_product->taxes = $cart_item_info['line_tax'];
+		$cart_event_product->total = $cart_item_info['line_total'];
+		$cart_event_product->quantity = $cart_item_info['quantity'];
+		$cart_event_product->product_url = $product_data->get_permalink();
+		$cart_event_product->image_url = $product_data->get_image('woocommerce_single', array(), true);
+		$cart_event_product->categories = $this->product_categories($product_data);
 
-    private function user_invalid() {
-        $wp_user = wp_get_current_user();
-        if( $wp_user && !empty($wp_user->user_email) ) {
-            return false;
-        }
-        return true; // no way to identify a Drip person.
-    }
+		return $cart_event_product;
+	}
 
-    private function product_key($cart_product_info) {
-        return empty($cart_product_info['variation_id'])? $cart_product_info['product_id'] : $cart_product_info['variation_id'];
-    }
+	private function user_invalid() {
+		$wp_user = wp_get_current_user();
+		if( $wp_user && !empty($wp_user->user_email) ) {
+			return false;
+		}
+		return true; // no way to identify a Drip person.
+	}
 
-    private function product_categories($product_data) {
-        $categories = array();
-        foreach($product_data->get_category_ids() as $cid) {
-            $woo_category = get_term_by( 'id', absint( $cid ), 'product_cat' );
-            array_push($categories, $woo_category->name);
-        }
-        return $categories;
-    }
+	private function product_key($cart_product_info) {
+		return empty($cart_product_info['variation_id'])? $cart_product_info['product_id'] : $cart_product_info['variation_id'];
+	}
 
-    private function drip_cart_session_id()
-    {
-        $cid = WC()->session->get( self::CART_SESSION_KEY, false);
-        if($cid) { return $cid; }
-        $cid = $this->generate_drip_cart_session_id();
-        WC()->session->set( self::CART_SESSION_KEY, $cid);
-        return $cid;
-    }
+	private function product_categories($product_data) {
+		$categories = array();
+		foreach($product_data->get_category_ids() as $cid) {
+			$woo_category = get_term_by( 'id', absint( $cid ), 'product_cat' );
+			array_push($categories, $woo_category->name);
+		}
+		return $categories;
+	}
 
-    private function remove_drip_cart_session_id()
-    {
-        WC()->session->__unset( self::CART_SESSION_KEY );
-    }
+	private function drip_cart_session_id()
+	{
+		$cid = WC()->session->get( self::CART_SESSION_KEY, false);
+		if($cid) { return $cid; }
+		$cid = $this->generate_drip_cart_session_id();
+		WC()->session->set( self::CART_SESSION_KEY, $cid);
+		return $cid;
+	}
 
-    private function generate_drip_cart_session_id()
-    {
-        $random_data = random_bytes(32); // as of php7, random_bytes is advertised as cryptographically secure
-        return hash('sha256',  $random_data); 
-    }
+	private function remove_drip_cart_session_id()
+	{
+		WC()->session->__unset( self::CART_SESSION_KEY );
+	}
+
+	private function generate_drip_cart_session_id()
+	{
+		$random_data = random_bytes(32); // as of php7, random_bytes is advertised as cryptographically secure
+		return hash('sha256',  $random_data);
+	}
 }
 
 //
 
 class Drip_Woocommerce_Cart_Event
 {
-    public $event_action;
-    public $customer_email;
-    public $session;
-    public $grand_total;
-    public $total_discounts;
-    public $total_taxes;
-    public $total_fees;
-    public $total_shipping;
-    public $currency;
-    public $cart_data = array();
+	public $event_action;
+	public $customer_email;
+	public $session;
+	public $grand_total;
+	public $total_discounts;
+	public $total_taxes;
+	public $total_fees;
+	public $total_shipping;
+	public $currency;
+	public $cart_data = array();
 }
 
 class Drip_Woocommerce_Cart_Event_Product
 {
-    public $product_id;
-    public $product_variant_id;
-    public $sku;
-    public $name;
-    public $short_description;
-    public $price;
-    public $taxes;
-    public $total;
-    public $quantity;
-    public $product_url;
-    public $image_url;
-    public $categories = array();
+	public $product_id;
+	public $product_variant_id;
+	public $sku;
+	public $name;
+	public $short_description;
+	public $price;
+	public $taxes;
+	public $total;
+	public $quantity;
+	public $product_url;
+	public $image_url;
+	public $categories = array();
 }

--- a/src/class-drip-woocommerce-cart-events.php
+++ b/src/class-drip-woocommerce-cart-events.php
@@ -1,155 +1,174 @@
 <?php
+/**
+ * Cart event handling
+ *
+ * @package Drip_Woocommerce
+ */
 
 defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
-class Drip_Woocommerce_Cart_Events
-{
-	const CART_SESSION_KEY = "drip_cart_session_id";
+require_once __DIR__ . '/class-drip-woocommerce-cart-event.php';
+require_once __DIR__ . '/class-drip-woocommerce-cart-event-product.php';
+
+/**
+ * Cart event handling
+ */
+class Drip_Woocommerce_Cart_Events {
+	const CART_SESSION_KEY    = 'drip_cart_session_id';
 	const CART_UPDATED_ACTION = 'updated';
 
-	public static function init()
-	{
+	/**
+	 * Set up component
+	 */
+	public static function init() {
 		$cart_events = new Drip_Woocommerce_Cart_Events();
 		$cart_events->setup_cart_actions();
 	}
 
-	public function setup_cart_actions()
-	{
-		add_action( 'woocommerce_after_cart_item_quantity_update', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
-		add_action( 'woocommerce_cart_item_removed', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
-		add_action( 'woocommerce_add_to_cart', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
-		add_action( 'woocommerce_cart_item_restored', array($this, 'drip_woocommerce_cart_updated'), 10, 0 );
-		add_action( 'woocommerce_cart_emptied', array($this, 'drip_woocommerce_cart_updated'), 10, 0  ); // no way to get this from the UI without plugins
+	/**
+	 * Set up cart action callbacks
+	 */
+	public function setup_cart_actions() {
+		add_action( 'woocommerce_after_cart_item_quantity_update', array( $this, 'drip_woocommerce_cart_updated' ), 10, 0 );
+		add_action( 'woocommerce_cart_item_removed', array( $this, 'drip_woocommerce_cart_updated' ), 10, 0 );
+		add_action( 'woocommerce_add_to_cart', array( $this, 'drip_woocommerce_cart_updated' ), 10, 0 );
+		add_action( 'woocommerce_cart_item_restored', array( $this, 'drip_woocommerce_cart_updated' ), 10, 0 );
+		add_action( 'woocommerce_cart_emptied', array( $this, 'drip_woocommerce_cart_updated' ), 10, 0 ); // no way to get this from the UI without plugins.
 	}
 
+	/**
+	 * Callback for cart actions
+	 */
 	public function drip_woocommerce_cart_updated() {
-		if( $this->user_invalid() ) { return; }
+		if ( $this->user_invalid() ) {
+			return;
+		}
 
 		$event = $this->base_event();
 
 		$cart_contents = WC()->cart->get_cart();
-		foreach( $cart_contents as $product_id => $cart_item_info ) {
-			$product_event_data = $this->product_event_data($cart_item_info);
-			if($product_event_data) {
-				$event->cart_data[$product_id] = $product_event_data;
+		foreach ( $cart_contents as $product_id => $cart_item_info ) {
+			$product_event_data = $this->product_event_data( $cart_item_info );
+			if ( $product_event_data ) {
+				$event->cart_data[ $product_id ] = $product_event_data;
 			}
 		}
-		do_action( 'wc_drip_woocommerce_cart_event', base64_encode( json_encode( $event ) ) );
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		do_action( 'wc_drip_woocommerce_cart_event', base64_encode( wp_json_encode( $event ) ) );
 
-		if(WC()->cart->is_empty()) {
+		if ( WC()->cart->is_empty() ) {
 			$this->remove_drip_cart_session_id();
 		}
 	}
 
+	/**
+	 * Create a basic event
+	 */
 	private function base_event() {
 		WC()->cart->calculate_totals();
 
-		$event = new Drip_Woocommerce_Cart_Event();
-		$event->event_action = self::CART_UPDATED_ACTION; // TODO: we can trap cart created events if we have to generate a new cart session id
-		$event->customer_email = wp_get_current_user()->user_email;
-		$event->session = $this->drip_cart_session_id();
-		$event->grand_total = WC()->cart->get_total('drip_woocommerce');
-		$event->total_discounts = WC()->cart->get_discount_total('drip_woocommerce');
-		$event->total_taxes = WC()->cart->get_total_tax('drip_woocommerce');
-		$event->total_fees = WC()->cart->get_fee_total('drip_woocommerce');
-		$event->total_shipping = WC()->cart->get_shipping_total('drip_woocommerce');
-		$event->currency = get_option('woocommerce_currency');
+		$event                  = new Drip_Woocommerce_Cart_Event();
+		$event->event_action    = self::CART_UPDATED_ACTION; // TODO: we can trap cart created events if we have to generate a new cart session id.
+		$event->customer_email  = wp_get_current_user()->user_email;
+		$event->session         = $this->drip_cart_session_id();
+		$event->grand_total     = WC()->cart->get_total( 'drip_woocommerce' );
+		$event->total_discounts = WC()->cart->get_discount_total( 'drip_woocommerce' );
+		$event->total_taxes     = WC()->cart->get_total_tax( 'drip_woocommerce' );
+		$event->total_fees      = WC()->cart->get_fee_total( 'drip_woocommerce' );
+		$event->total_shipping  = WC()->cart->get_shipping_total( 'drip_woocommerce' );
+		$event->currency        = get_option( 'woocommerce_currency' );
 		return $event;
 	}
 
-	private function product_event_data($cart_item_info) {
-		$product_key = $this->product_key($cart_item_info);
+	/**
+	 * Set up product event data
+	 *
+	 * @param array $cart_item_info information about the cart.
+	 */
+	private function product_event_data( $cart_item_info ) {
+		$product_key  = $this->product_key( $cart_item_info );
 		$product_data = WC()->product_factory->get_product( $product_key );
 
-		if( ! $product_data ) { return false; }
+		if ( ! $product_data ) {
+			return false;
+		}
 
-		$cart_event_product = new Drip_Woocommerce_Cart_Event_Product();
-		$cart_event_product->product_id =$cart_item_info['product_id'];
+		$cart_event_product                     = new Drip_Woocommerce_Cart_Event_Product();
+		$cart_event_product->product_id         = $cart_item_info['product_id'];
 		$cart_event_product->product_variant_id = $product_key;
-		$cart_event_product->sku = $product_data->get_sku('drip_woocommerce');
-		$cart_event_product->name = $product_data->get_name('drip_woocommerce');
-		$cart_event_product->short_description = $product_data->get_short_description('drip_woocommerce');
-		$cart_event_product->price = $product_data->get_price('drip_woocommerce');
-		$cart_event_product->taxes = $cart_item_info['line_tax'];
-		$cart_event_product->total = $cart_item_info['line_total'];
-		$cart_event_product->quantity = $cart_item_info['quantity'];
-		$cart_event_product->product_url = $product_data->get_permalink();
-		$cart_event_product->image_url = $product_data->get_image('woocommerce_single', array(), true);
-		$cart_event_product->categories = $this->product_categories($product_data);
+		$cart_event_product->sku                = $product_data->get_sku( 'drip_woocommerce' );
+		$cart_event_product->name               = $product_data->get_name( 'drip_woocommerce' );
+		$cart_event_product->short_description  = $product_data->get_short_description( 'drip_woocommerce' );
+		$cart_event_product->price              = $product_data->get_price( 'drip_woocommerce' );
+		$cart_event_product->taxes              = $cart_item_info['line_tax'];
+		$cart_event_product->total              = $cart_item_info['line_total'];
+		$cart_event_product->quantity           = $cart_item_info['quantity'];
+		$cart_event_product->product_url        = $product_data->get_permalink();
+		$cart_event_product->image_url          = $product_data->get_image( 'woocommerce_single', array(), true );
+		$cart_event_product->categories         = $this->product_categories( $product_data );
 
 		return $cart_event_product;
 	}
 
+	/**
+	 * Check for user validity
+	 */
 	private function user_invalid() {
 		$wp_user = wp_get_current_user();
-		if( $wp_user && !empty($wp_user->user_email) ) {
+		if ( $wp_user && ! empty( $wp_user->user_email ) ) {
 			return false;
 		}
 		return true; // no way to identify a Drip person.
 	}
 
-	private function product_key($cart_product_info) {
-		return empty($cart_product_info['variation_id'])? $cart_product_info['product_id'] : $cart_product_info['variation_id'];
+	/**
+	 * Get the product's key
+	 *
+	 * @param array $cart_product_info information about the cart.
+	 */
+	private function product_key( $cart_product_info ) {
+		return empty( $cart_product_info['variation_id'] ) ? $cart_product_info['product_id'] : $cart_product_info['variation_id'];
 	}
 
-	private function product_categories($product_data) {
+	/**
+	 * Obtain categories for product
+	 *
+	 * @param mixed $product_data Product data.
+	 */
+	private function product_categories( $product_data ) {
 		$categories = array();
-		foreach($product_data->get_category_ids() as $cid) {
+		foreach ( $product_data->get_category_ids() as $cid ) {
 			$woo_category = get_term_by( 'id', absint( $cid ), 'product_cat' );
-			array_push($categories, $woo_category->name);
+			array_push( $categories, $woo_category->name );
 		}
 		return $categories;
 	}
 
-	private function drip_cart_session_id()
-	{
-		$cid = WC()->session->get( self::CART_SESSION_KEY, false);
-		if($cid) { return $cid; }
+	/**
+	 * Get the drip cart id from the session
+	 */
+	private function drip_cart_session_id() {
+		$cid = WC()->session->get( self::CART_SESSION_KEY, false );
+		if ( $cid ) {
+			return $cid;
+		}
 		$cid = $this->generate_drip_cart_session_id();
-		WC()->session->set( self::CART_SESSION_KEY, $cid);
+		WC()->session->set( self::CART_SESSION_KEY, $cid );
 		return $cid;
 	}
 
-	private function remove_drip_cart_session_id()
-	{
+	/**
+	 * Unset the drip cart id from the session
+	 */
+	private function remove_drip_cart_session_id() {
 		WC()->session->__unset( self::CART_SESSION_KEY );
 	}
 
-	private function generate_drip_cart_session_id()
-	{
-		$random_data = random_bytes(32); // as of php7, random_bytes is advertised as cryptographically secure
-		return hash('sha256',  $random_data);
+	/**
+	 * Generate a drip cart id in the session
+	 */
+	private function generate_drip_cart_session_id() {
+		$random_data = random_bytes( 32 ); // as of php7, random_bytes is advertised as cryptographically secure.
+		return hash( 'sha256', $random_data );
 	}
-}
-
-//
-
-class Drip_Woocommerce_Cart_Event
-{
-	public $event_action;
-	public $customer_email;
-	public $session;
-	public $grand_total;
-	public $total_discounts;
-	public $total_taxes;
-	public $total_fees;
-	public $total_shipping;
-	public $currency;
-	public $cart_data = array();
-}
-
-class Drip_Woocommerce_Cart_Event_Product
-{
-	public $product_id;
-	public $product_variant_id;
-	public $sku;
-	public $name;
-	public $short_description;
-	public $price;
-	public $taxes;
-	public $total;
-	public $quantity;
-	public $product_url;
-	public $image_url;
-	public $categories = array();
 }

--- a/src/class-drip-woocommerce-settings.php
+++ b/src/class-drip-woocommerce-settings.php
@@ -1,17 +1,25 @@
 <?php
+/**
+ * Management for plugin settings
+ *
+ * @package Drip_Woocommerce
+ */
+
+/**
+ * Management for plugin settings
+ */
 class Drip_Woocommerce_Settings {
-	const NAME = "woocommerce-settings-drip";
-	const ACCOUNT_ID_KEY = "account_id";
+	const NAME           = 'woocommerce-settings-drip';
+	const ACCOUNT_ID_KEY = 'account_id';
 
 	/**
 	 * Bootstraps the class and hooks required actions & filters.
-	 *
 	 */
 	public static function init() {
 		add_filter( 'woocommerce_settings_tabs_array', __CLASS__ . '::add_settings_tab', 50 );
 		add_action( 'woocommerce_settings_tabs_settings_drip', __CLASS__ . '::settings_tab' );
-		add_filter( 'woocommerce_settings_groups', __CLASS__ . '::settings_group');
-		add_filter( 'woocommerce_settings-drip', __CLASS__ . '::settings_group_options');
+		add_filter( 'woocommerce_settings_groups', __CLASS__ . '::settings_group' );
+		add_filter( 'woocommerce_settings-drip', __CLASS__ . '::settings_group_options' );
 	}
 
 
@@ -39,6 +47,8 @@ class Drip_Woocommerce_Settings {
 
 	/**
 	 * Register the `drip` settings group.
+	 *
+	 * @param array $locations Locations within the settings group.
 	 */
 	public static function settings_group( $locations ) {
 		$locations[] = array(
@@ -51,6 +61,8 @@ class Drip_Woocommerce_Settings {
 
 	/**
 	 * Register options under `drip` settings group.
+	 *
+	 * @param array $settings Settings group to register.
 	 */
 	public static function settings_group_options( $settings ) {
 		$settings[] = array(
@@ -71,25 +83,26 @@ class Drip_Woocommerce_Settings {
 	 */
 	public static function get_settings() {
 		$settings = array(
-			'section_title' => array(
+			'section_title'      => array(
 				'id'   => 'wc_settings_drip_section_title',
 				'name' => __( 'Drip', self::NAME ),
 				'type' => 'title',
 				'desc' => '',
 			),
 			self::ACCOUNT_ID_KEY => array(
-				'id'   => self::ACCOUNT_ID_KEY,
-				'name' => __( 'Account ID', self::NAME ),
-				'type' => 'number',
-				'desc' => __( 'Read-only, visible if integration was successful', self::NAME ),
-				'custom_attributes' => array('readonly' => 'readonly'),
+				'id'                => self::ACCOUNT_ID_KEY,
+				'name'              => __( 'Account ID', self::NAME ),
+				'type'              => 'number',
+				'desc'              => __( 'Read-only, visible if integration was successful', self::NAME ),
+				'custom_attributes' => array( 'readonly' => 'readonly' ),
 			),
-			'section_end' => array(
+			'section_end'        => array(
 				'type' => 'sectionend',
-				'id'   => 'wc_settings_drip_section_end'
-			)
+				'id'   => 'wc_settings_drip_section_end',
+			),
 		);
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		return apply_filters( 'wc_settings_drip_settings', $settings );
 	}
 }

--- a/src/class-drip-woocommerce-settings.php
+++ b/src/class-drip-woocommerce-settings.php
@@ -1,95 +1,95 @@
 <?php
 class Drip_Woocommerce_Settings {
-  const NAME = "woocommerce-settings-drip";
-  const ACCOUNT_ID_KEY = "account_id";
+	const NAME = "woocommerce-settings-drip";
+	const ACCOUNT_ID_KEY = "account_id";
 
-  /**
-   * Bootstraps the class and hooks required actions & filters.
-   *
-   */
-  public static function init() {
-    add_filter( 'woocommerce_settings_tabs_array', __CLASS__ . '::add_settings_tab', 50 );
-    add_action( 'woocommerce_settings_tabs_settings_drip', __CLASS__ . '::settings_tab' );
-    add_filter( 'woocommerce_settings_groups', __CLASS__ . '::settings_group');
-    add_filter( 'woocommerce_settings-drip', __CLASS__ . '::settings_group_options');
-  }
-
-
-  /**
-   * Add a new settings tab to the WooCommerce settings tabs array.
-   *
-   * @param array $settings_tabs Array of WooCommerce setting tabs & their labels, excluding the Subscription tab.
-   * @return array $settings_tabs Array of WooCommerce setting tabs & their labels, including the Subscription tab.
-   */
-  public static function add_settings_tab( $settings_tabs ) {
-    $settings_tabs['settings_drip'] = __( 'Drip', self::NAME );
-    return $settings_tabs;
-  }
+	/**
+	 * Bootstraps the class and hooks required actions & filters.
+	 *
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_settings_tabs_array', __CLASS__ . '::add_settings_tab', 50 );
+		add_action( 'woocommerce_settings_tabs_settings_drip', __CLASS__ . '::settings_tab' );
+		add_filter( 'woocommerce_settings_groups', __CLASS__ . '::settings_group');
+		add_filter( 'woocommerce_settings-drip', __CLASS__ . '::settings_group_options');
+	}
 
 
-  /**
-   * Uses the WooCommerce admin fields API to output settings via the @see woocommerce_admin_fields() function.
-   *
-   * @uses woocommerce_admin_fields()
-   * @uses self::get_settings()
-   */
-  public static function settings_tab() {
-    woocommerce_admin_fields( self::get_settings() );
-  }
+	/**
+	 * Add a new settings tab to the WooCommerce settings tabs array.
+	 *
+	 * @param array $settings_tabs Array of WooCommerce setting tabs & their labels, excluding the Subscription tab.
+	 * @return array $settings_tabs Array of WooCommerce setting tabs & their labels, including the Subscription tab.
+	 */
+	public static function add_settings_tab( $settings_tabs ) {
+		$settings_tabs['settings_drip'] = __( 'Drip', self::NAME );
+		return $settings_tabs;
+	}
 
-  /**
-   * Register the `drip` settings group.
-   */
-  public static function settings_group( $locations ) {
-    $locations[] = array(
-      'id'          => 'drip',
-      'label'       => __( 'Drip', self::NAME ),
-      'description' => __( 'Drip Settings', self::NAME ),
-    );
-    return $locations;
-  }
 
-  /**
-   * Register options under `drip` settings group.
-   */
-  public static function settings_group_options( $settings ) {
-    $settings[] = array(
-      'id'          => self::ACCOUNT_ID_KEY,
-      'option_key'  => self::ACCOUNT_ID_KEY,
-      'label'       => __( 'Account ID', self::NAME ),
-      'description' => __( 'Drip Account ID', self::NAME ),
-      'default'     => '',
-      'type'        => 'number',
-    );
-    return $settings;
-  }
+	/**
+	 * Uses the WooCommerce admin fields API to output settings via the @see woocommerce_admin_fields() function.
+	 *
+	 * @uses woocommerce_admin_fields()
+	 * @uses self::get_settings()
+	 */
+	public static function settings_tab() {
+		woocommerce_admin_fields( self::get_settings() );
+	}
 
-  /**
-   * Get all the settings for this plugin for @see woocommerce_admin_fields() function.
-   *
-   * @return array Array of settings for @see woocommerce_admin_fields() function.
-   */
-  public static function get_settings() {
-    $settings = array(
-      'section_title' => array(
-        'id'   => 'wc_settings_drip_section_title',
-        'name' => __( 'Drip', self::NAME ),
-        'type' => 'title',
-        'desc' => '',
-      ),
-      self::ACCOUNT_ID_KEY => array(
-        'id'   => self::ACCOUNT_ID_KEY,
-        'name' => __( 'Account ID', self::NAME ),
-        'type' => 'number',
-        'desc' => __( 'Read-only, visible if integration was successful', self::NAME ),
-        'custom_attributes' => array('readonly' => 'readonly'),
-      ),
-      'section_end' => array(
-        'type' => 'sectionend',
-        'id'   => 'wc_settings_drip_section_end'
-      )
-    );
+	/**
+	 * Register the `drip` settings group.
+	 */
+	public static function settings_group( $locations ) {
+		$locations[] = array(
+			'id'          => 'drip',
+			'label'       => __( 'Drip', self::NAME ),
+			'description' => __( 'Drip Settings', self::NAME ),
+		);
+		return $locations;
+	}
 
-    return apply_filters( 'wc_settings_drip_settings', $settings );
-  }
+	/**
+	 * Register options under `drip` settings group.
+	 */
+	public static function settings_group_options( $settings ) {
+		$settings[] = array(
+			'id'          => self::ACCOUNT_ID_KEY,
+			'option_key'  => self::ACCOUNT_ID_KEY,
+			'label'       => __( 'Account ID', self::NAME ),
+			'description' => __( 'Drip Account ID', self::NAME ),
+			'default'     => '',
+			'type'        => 'number',
+		);
+		return $settings;
+	}
+
+	/**
+	 * Get all the settings for this plugin for @see woocommerce_admin_fields() function.
+	 *
+	 * @return array Array of settings for @see woocommerce_admin_fields() function.
+	 */
+	public static function get_settings() {
+		$settings = array(
+			'section_title' => array(
+				'id'   => 'wc_settings_drip_section_title',
+				'name' => __( 'Drip', self::NAME ),
+				'type' => 'title',
+				'desc' => '',
+			),
+			self::ACCOUNT_ID_KEY => array(
+				'id'   => self::ACCOUNT_ID_KEY,
+				'name' => __( 'Account ID', self::NAME ),
+				'type' => 'number',
+				'desc' => __( 'Read-only, visible if integration was successful', self::NAME ),
+				'custom_attributes' => array('readonly' => 'readonly'),
+			),
+			'section_end' => array(
+				'type' => 'sectionend',
+				'id'   => 'wc_settings_drip_section_end'
+			)
+		);
+
+		return apply_filters( 'wc_settings_drip_settings', $settings );
+	}
 }

--- a/src/class-drip-woocommerce-snippet.php
+++ b/src/class-drip-woocommerce-snippet.php
@@ -1,17 +1,36 @@
 <?php
+/**
+ * Injects Drip JS snippet
+ *
+ * @package Drip_Woocommerce
+ */
+
+/**
+ * Injects Drip JS snippet
+ */
 class Drip_Woocommerce_Snippet {
+	/**
+	 * Set up component
+	 */
 	public static function init() {
-		add_action( "wp_footer", __CLASS__ . "::render_snippet" );
+		add_action( 'wp_footer', __CLASS__ . '::render_snippet' );
 	}
 
+	/**
+	 * Render JS snippet
+	 */
 	public static function render_snippet() {
-		if ( $account_id = self::get_account_id() ) {
-			include( "snippet.js.php" );
+		$account_id = self::get_account_id();
+		if ( $account_id ) {
+			include 'snippet.js.php';
 		} else {
-			echo "<!-- Add your woocommerce credentials in Drip to begin tracking -->";
+			echo '<!-- Add your woocommerce credentials in Drip to begin tracking -->';
 		}
 	}
 
+	/**
+	 * Get the account ID from settings
+	 */
 	public static function get_account_id() {
 		return WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::ACCOUNT_ID_KEY );
 	}

--- a/src/class-drip-woocommerce-snippet.php
+++ b/src/class-drip-woocommerce-snippet.php
@@ -1,18 +1,18 @@
 <?php
 class Drip_Woocommerce_Snippet {
-  public static function init() {
-    add_action( "wp_footer", __CLASS__ . "::render_snippet" );
-  }
+	public static function init() {
+		add_action( "wp_footer", __CLASS__ . "::render_snippet" );
+	}
 
-  public static function render_snippet() {
-    if ( $account_id = self::get_account_id() ) {
-      include( "snippet.js.php" );
-    } else {
-      echo "<!-- Add your woocommerce credentials in Drip to begin tracking -->";
-    }
-  }
+	public static function render_snippet() {
+		if ( $account_id = self::get_account_id() ) {
+			include( "snippet.js.php" );
+		} else {
+			echo "<!-- Add your woocommerce credentials in Drip to begin tracking -->";
+		}
+	}
 
-  public static function get_account_id() {
-    return WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::ACCOUNT_ID_KEY );
-  }
+	public static function get_account_id() {
+		return WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::ACCOUNT_ID_KEY );
+	}
 }

--- a/src/class-drip-woocommerce-version.php
+++ b/src/class-drip-woocommerce-version.php
@@ -1,28 +1,51 @@
 <?php
+/**
+ * Injects Drip plugin version header into relevant webhooks.
+ *
+ * @package Drip_Woocommerce
+ */
 
-require_once( ABSPATH . "wp-admin/includes/plugin.php" );
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
+/**
+ * Injects Drip plugin version header into relevant webhooks.
+ */
 class Drip_Woocommerce_Version {
-	const HEADER = "X-WC-Drip-Version";
+	const HEADER = 'X-WC-Drip-Version';
 
+	/**
+	 * Set up component
+	 */
 	public static function init() {
-		add_filter( "woocommerce_webhook_http_args", __CLASS__ . "::add_version_header", 50, 3 );
+		add_filter( 'woocommerce_webhook_http_args', __CLASS__ . '::add_version_header', 50, 3 );
 	}
 
+	/**
+	 * Callback for woocommerce_webhook_http_args filter
+	 *
+	 * @param  array  $http_args argument for the http request.
+	 * @param  mixed  $_arg      unused.
+	 * @param string $this_id   the ID of the webhook.
+	 */
 	public static function add_version_header( $http_args, $_arg, $this_id ) {
-		// $this_id is webhook id
-		$webhook_name = (new WC_Webhook($this_id))->get_name();
-		if ( strpos(strtolower($webhook_name), "drip") !== false ) {
-			if ( $version = self::my_plugin_data( "Version" ) ) {
-				$http_args["headers"][self::HEADER] = $version;
+		$webhook_name = ( new WC_Webhook( $this_id ) )->get_name();
+		if ( strpos( strtolower( $webhook_name ), 'drip' ) !== false ) {
+			$version = self::my_plugin_data( 'Version' );
+			if ( $version ) {
+				$http_args['headers'][ self::HEADER ] = $version;
 			}
 		}
 		return $http_args;
 	}
 
+	/**
+	 * Get data out of plugin frontmatter.
+	 *
+	 * @param string $attribute a plugin attribute.
+	 */
 	private static function my_plugin_data( $attribute ) {
-		$path = realpath(__DIR__ . "/../drip-woocommerce.php");
+		$path        = realpath( __DIR__ . '/../drip-woocommerce.php' );
 		$plugin_data = get_plugin_data( $path );
-		return trim($plugin_data[$attribute]);
+		return trim( $plugin_data[ $attribute ] );
 	}
 }

--- a/src/class-drip-woocommerce-version.php
+++ b/src/class-drip-woocommerce-version.php
@@ -5,6 +5,8 @@
  * @package Drip_Woocommerce
  */
 
+defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
+
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 /**

--- a/src/class-drip-woocommerce-version.php
+++ b/src/class-drip-woocommerce-version.php
@@ -3,26 +3,26 @@
 require_once( ABSPATH . "wp-admin/includes/plugin.php" );
 
 class Drip_Woocommerce_Version {
-  const HEADER = "X-WC-Drip-Version";
+	const HEADER = "X-WC-Drip-Version";
 
-  public static function init() {
-    add_filter( "woocommerce_webhook_http_args", __CLASS__ . "::add_version_header", 50, 3 );
-  }
+	public static function init() {
+		add_filter( "woocommerce_webhook_http_args", __CLASS__ . "::add_version_header", 50, 3 );
+	}
 
-  public static function add_version_header( $http_args, $_arg, $this_id ) {
-    // $this_id is webhook id
-    $webhook_name = (new WC_Webhook($this_id))->get_name();
-    if ( strpos(strtolower($webhook_name), "drip") !== false ) {
-      if ( $version = self::my_plugin_data( "Version" ) ) {
-        $http_args["headers"][self::HEADER] = $version;
-      }
-    }
-    return $http_args;
-  }
+	public static function add_version_header( $http_args, $_arg, $this_id ) {
+		// $this_id is webhook id
+		$webhook_name = (new WC_Webhook($this_id))->get_name();
+		if ( strpos(strtolower($webhook_name), "drip") !== false ) {
+			if ( $version = self::my_plugin_data( "Version" ) ) {
+				$http_args["headers"][self::HEADER] = $version;
+			}
+		}
+		return $http_args;
+	}
 
-  private static function my_plugin_data( $attribute ) {
-    $path = realpath(__DIR__ . "/../drip-woocommerce.php");
-    $plugin_data = get_plugin_data( $path );
-    return trim($plugin_data[$attribute]);
-  }
+	private static function my_plugin_data( $attribute ) {
+		$path = realpath(__DIR__ . "/../drip-woocommerce.php");
+		$plugin_data = get_plugin_data( $path );
+		return trim($plugin_data[$attribute]);
+	}
 }

--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -4,43 +4,43 @@ defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
 class Drip_Woocommerce_View_Events
 {
-    public static function init()
-    {
-        $view_events = new Drip_Woocommerce_View_Events();
-        $view_events->setup_view_actions();
-    }
+	public static function init()
+	{
+		$view_events = new Drip_Woocommerce_View_Events();
+		$view_events->setup_view_actions();
+	}
 
-    public function setup_view_actions()
-    {
-        add_action( 'woocommerce_after_single_product', array($this, 'drip_woocommerce_viewed_product'), 10 );
-    }
+	public function setup_view_actions()
+	{
+		add_action( 'woocommerce_after_single_product', array($this, 'drip_woocommerce_viewed_product'), 10 );
+	}
 
-    public function drip_woocommerce_viewed_product() {
-      wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js' );
-      $product = wc_get_product();
-      $product_attributes = array(
-        "product_id" => $product->get_id('drip_woocommerce'),
-        "product_variant_id" => $product->get_variation_id('drip_woocommerce'),
-        "sku" => $product->get_sku('drip_woocommerce'),
-        "name" => $product->get_name('drip_woocommerce'),
-        "price" => $product->get_price('drip_woocommerce'),
-        "product_url" => $product->get_permalink(),
-        "currency" => get_option('woocommerce_currency'),
-        "categories" => $this->product_categories($product),
-        "image_id"  => $product->get_image_id(),
-        "image_url" => wp_get_attachment_image_url( $image_id )
-      );
+	public function drip_woocommerce_viewed_product() {
+	  wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js' );
+	  $product = wc_get_product();
+	  $product_attributes = array(
+		"product_id" => $product->get_id('drip_woocommerce'),
+		"product_variant_id" => $product->get_variation_id('drip_woocommerce'),
+		"sku" => $product->get_sku('drip_woocommerce'),
+		"name" => $product->get_name('drip_woocommerce'),
+		"price" => $product->get_price('drip_woocommerce'),
+		"product_url" => $product->get_permalink(),
+		"currency" => get_option('woocommerce_currency'),
+		"categories" => $this->product_categories($product),
+		"image_id"  => $product->get_image_id(),
+		"image_url" => wp_get_attachment_image_url( $image_id )
+	  );
 
-      wp_localize_script( 'Drip product view tracking', 'product', $product_attributes );
-      wp_enqueue_script('Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), 1.0, true);
-    }
+	  wp_localize_script( 'Drip product view tracking', 'product', $product_attributes );
+	  wp_enqueue_script('Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), 1.0, true);
+	}
 
-    private function product_categories($product) {
-        $categories = array();
-        foreach($product->get_category_ids() as $cid) {
-            $woo_category = get_term_by( 'id', absint( $cid ), 'product_cat' );
-            array_push($categories, $woo_category->name);
-        }
-        return join(',', $categories);
-    }
+	private function product_categories($product) {
+		$categories = array();
+		foreach($product->get_category_ids() as $cid) {
+			$woo_category = get_term_by( 'id', absint( $cid ), 'product_cat' );
+			array_push($categories, $woo_category->name);
+		}
+		return join(',', $categories);
+	}
 }

--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -1,46 +1,65 @@
 <?php
+/**
+ * Manage viewed a product events
+ *
+ * @package Drip_Woocommerce
+ */
 
 defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
-class Drip_Woocommerce_View_Events
-{
-	public static function init()
-	{
+/**
+ * Manage viewed a product events
+ */
+class Drip_Woocommerce_View_Events {
+	/**
+	 * Set up component
+	 */
+	public static function init() {
 		$view_events = new Drip_Woocommerce_View_Events();
 		$view_events->setup_view_actions();
 	}
 
-	public function setup_view_actions()
-	{
-		add_action( 'woocommerce_after_single_product', array($this, 'drip_woocommerce_viewed_product'), 10 );
+	/**
+	 * Start processing view actions
+	 */
+	public function setup_view_actions() {
+		add_action( 'woocommerce_after_single_product', array( $this, 'drip_woocommerce_viewed_product' ), 10 );
 	}
 
+	/**
+	 * Handler for woocommerce_after_single_product action
+	 */
 	public function drip_woocommerce_viewed_product() {
-	  wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js' );
-	  $product = wc_get_product();
-	  $product_attributes = array(
-		"product_id" => $product->get_id('drip_woocommerce'),
-		"product_variant_id" => $product->get_variation_id('drip_woocommerce'),
-		"sku" => $product->get_sku('drip_woocommerce'),
-		"name" => $product->get_name('drip_woocommerce'),
-		"price" => $product->get_price('drip_woocommerce'),
-		"product_url" => $product->get_permalink(),
-		"currency" => get_option('woocommerce_currency'),
-		"categories" => $this->product_categories($product),
-		"image_id"  => $product->get_image_id(),
-		"image_url" => wp_get_attachment_image_url( $image_id )
-	  );
+		wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), '1', true );
+		$product            = wc_get_product();
+		$product_attributes = array(
+			'product_id'         => $product->get_id( 'drip_woocommerce' ),
+			'product_variant_id' => $product->get_variation_id( 'drip_woocommerce' ),
+			'sku'                => $product->get_sku( 'drip_woocommerce' ),
+			'name'               => $product->get_name( 'drip_woocommerce' ),
+			'price'              => $product->get_price( 'drip_woocommerce' ),
+			'product_url'        => $product->get_permalink(),
+			'currency'           => get_option( 'woocommerce_currency' ),
+			'categories'         => $this->product_categories( $product ),
+			'image_id'           => $product->get_image_id(),
+			'image_url'          => wp_get_attachment_image_url( $image_id ),
+		);
 
-	  wp_localize_script( 'Drip product view tracking', 'product', $product_attributes );
-	  wp_enqueue_script('Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), 1.0, true);
+		wp_localize_script( 'Drip product view tracking', 'product', $product_attributes );
+		wp_enqueue_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), 1.0, true );
 	}
 
-	private function product_categories($product) {
+	/**
+	 * Get the categories for a product
+	 *
+	 * @param WC_Product $product A WooCommerce product.
+	 */
+	private function product_categories( $product ) {
 		$categories = array();
-		foreach($product->get_category_ids() as $cid) {
+		foreach ( $product->get_category_ids() as $cid ) {
 			$woo_category = get_term_by( 'id', absint( $cid ), 'product_cat' );
-			array_push($categories, $woo_category->name);
+			array_push( $categories, $woo_category->name );
 		}
-		return join(',', $categories);
+		return join( ',', $categories );
 	}
 }

--- a/src/snippet.js.php
+++ b/src/snippet.js.php
@@ -1,13 +1,22 @@
+<?php
+/**
+ * The Drip JS snippet
+ *
+ * @package Drip_Woocommerce
+ */
+
+?>
+
 <!-- Drip Code -->
 <script type="text/javascript">
 	var _dcq = _dcq || [];
 	var _dcs = _dcs || {};
-	_dcs.account = '<?php echo $account_id ?>';
+	_dcs.account = '<?php echo esc_js( $account_id ); ?>';
 
 	(function() {
 		var dc = document.createElement('script');
 		dc.type = 'text/javascript'; dc.async = true;
-		dc.src = '//tag.getdrip.com/<?php echo $account_id ?>.js';
+		dc.src = '//tag.getdrip.com/<?php echo esc_js( $account_id ); ?>.js';
 		var s = document.getElementsByTagName('script')[0];
 		s.parentNode.insertBefore(dc, s);
 	})();

--- a/src/snippet.js.php
+++ b/src/snippet.js.php
@@ -1,14 +1,14 @@
 <!-- Drip Code -->
 <script type="text/javascript">
-  var _dcq = _dcq || [];
-  var _dcs = _dcs || {};
-  _dcs.account = '<?php echo $account_id ?>';
+	var _dcq = _dcq || [];
+	var _dcs = _dcs || {};
+	_dcs.account = '<?php echo $account_id ?>';
 
-  (function() {
-    var dc = document.createElement('script');
-    dc.type = 'text/javascript'; dc.async = true;
-    dc.src = '//tag.getdrip.com/<?php echo $account_id ?>.js';
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(dc, s);
-  })();
+	(function() {
+		var dc = document.createElement('script');
+		dc.type = 'text/javascript'; dc.async = true;
+		dc.src = '//tag.getdrip.com/<?php echo $account_id ?>.js';
+		var s = document.getElementsByTagName('script')[0];
+		s.parentNode.insertBefore(dc, s);
+	})();
 </script>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,7 +23,7 @@ require_once $drip_woocommerce_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function drip_woocommerce_manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/drip-woocommerce.php';
+	require dirname( dirname( __FILE__ ) ) . '/drip.php';
 }
 tests_add_filter( 'muplugins_loaded', 'drip_woocommerce_manually_load_plugin' );
 


### PR DESCRIPTION
Before submitting to the WordPress plugin directory, we should probably pass the basic WP linter.

Best reviewed with whitespace ignored, since one of the linters was spaces -> tabs.