### PR TITLE
Validate that we are in the wordpress context whenever executing php

### DIFF
--- a/src/class-drip-woocommerce-cart-event-product.php
+++ b/src/class-drip-woocommerce-cart-event-product.php
@@ -5,6 +5,8 @@
  * @package Drip_Woocommerce
  */
 
+defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
+
 /**
  * Value object for cart event products
  */

--- a/src/class-drip-woocommerce-cart-event.php
+++ b/src/class-drip-woocommerce-cart-event.php
@@ -5,6 +5,8 @@
  * @package Drip_Woocommerce
  */
 
+defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
+
 /**
  * Value object for cart events
  */

--- a/src/class-drip-woocommerce-settings.php
+++ b/src/class-drip-woocommerce-settings.php
@@ -5,6 +5,8 @@
  * @package Drip_Woocommerce
  */
 
+defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
+
 /**
  * Management for plugin settings
  */

--- a/src/class-drip-woocommerce-snippet.php
+++ b/src/class-drip-woocommerce-snippet.php
@@ -5,6 +5,8 @@
  * @package Drip_Woocommerce
  */
 
+defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
+
 /**
  * Injects Drip JS snippet
  */

--- a/src/snippet.js.php
+++ b/src/snippet.js.php
@@ -5,6 +5,8 @@
  * @package Drip_Woocommerce
  */
 
+defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
+
 ?>
 
 <!-- Drip Code -->


### PR DESCRIPTION
It's a possible security issue in WordPress that code be reachable directly. For this reason, WP recommends that every PHP file verify that it is running within WP.