### PR TITLE
Add wordpress plugin publish script

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$dir"
+
+NAME=$(basename "$0")
+
+function usage() {
+  local ret=${1:-0}
+  >&2 cat <<-EOF
+USAGE $ ./${NAME} -r|--repository PATH/TO/SVN/REPO -v|--version VERSION [-n|--dry-run] [-h|--help]
+
+WHERE
+  repository  Path to local working copy of
+              https://plugins.svn.wordpress.org/drip/
+
+  version     Already released git tag of version to publish.
+              Use bin/release.sh to create and release new tag on github
+              prior to running this script.
+
+  dry-run     Do not commit tag to svn repo, just show status.
+
+  help        Print this message
+EOF
+  exit "$ret"
+}
+
+while (( "$#" )); do
+  case "$1" in
+    -r|--repository)
+      REPOSITORY=$2
+      shift 2
+      ;;
+    -v|--version)
+      VERSION=$2
+      shift 2
+      ;;
+    -n|--dry-run)
+      DRY_RUN="true"
+      shift 1
+      ;;
+    -h|--help)
+      usage
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*) # unsupported flags
+      >&2 echo "ERROR: Unsupported flag $1"
+      usage 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+
+# ensure working copy is clean
+
+if [[ ! -z "$(git status --porcelain)" ]]; then
+  >&2 echo "ERROR: your git working copy has local changes"
+  exit 1
+fi
+
+# validate repository
+
+if [[ -z "$REPOSITORY" ]]; then
+  >&2 echo "ERROR: repository is required"
+  usage 1
+elif [[ ! -d "$REPOSITORY" ]]; then
+  >&2 echo "ERROR: repository dir $REPOSITORY does not exist"
+  usage 1
+fi
+
+# validate version
+
+if [[ -z "$VERSION" ]]; then
+  >&2 echo "ERROR: version is required"
+  usage 1
+fi
+
+# check that tag for version already exists
+
+git fetch origin --tags >/dev/null 2>&1
+if ! git rev-parse "$VERSION^{tag}" >/dev/null 2>&1; then
+  >&2 echo "ERROR: tag for version in git repository does not exist: $VERSION"
+  exit 1
+fi
+
+# update repository
+
+cd "$REPOSITORY"
+
+if ! svn status -q; then
+  >&2 echo "ERROR: your svn working copy has local changes"
+  usage 1
+fi
+
+svn update >/dev/null 2>&1
+
+# Check that tag does not already exist in svn repository
+dst="$REPOSITORY/tags/$VERSION"
+if [[ -d "$dst" ]]; then
+  >&2 echo "ERROR: tag for version in svn repository already exists: $dst"
+  exit 1
+fi
+
+mkdir -p "$dst"
+
+cd "$dir"
+
+git archive --format=tar "$VERSION" \
+  license.txt \
+  readme.txt \
+  drip.php \
+  src \
+  | tar x -C "$dst"
+
+cd "$REPOSITORY"
+cp "tags/$VERSION/readme.txt" trunk/readme.txt
+
+if [[ "$DRY_RUN" = "true" ]]; then
+  svn status
+else
+  svn add trunk/readme.txt "tags/$VERSION"
+  svn commit -m "Publish version $VERSION"
+fi

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -33,7 +33,20 @@ fi
 
 echo "Using version from plugin metadata: $plugin_version"
 
-git fetch origin
+readme_version=$(grep -e '^Stable tag: ' readme.txt | awk '{print $2}')
+if [[ -z "$readme_version" ]]; then
+  >&2 echo "ERROR: unable to parse readme version from readme.txt"
+  exit 1
+fi
+
+if [[ "$readme_version" != "$plugin_version" ]]; then
+  >&2 echo "ERROR: version from plugin metadata ($plugin_version) and readme ($readme_version) do not match"
+  exit 1
+fi
+
+echo "Using plugin version: $plugin_version"
+
+git fetch origin --tags
 
 if git tag | grep -q "$plugin_version"; then
   >&2 echo "ERROR: tag $plugin_version already exists!"


### PR DESCRIPTION
Addresses: https://dripcom.atlassian.net/browse/ECI-402

Explored the git-svn bridge approach and it felt overly complicated. So instead, this is just a simple shell script to assist in copying the release files from the git working copy to the svn working copy in a consistent way.

Note: This script just copies `readme.txt` to `trunk` and the minimum plugin files to `tags/$VERSION` for a given tag. This felt like the simplest approach to me, but would like to hear others thoughts on this as well.

Note: This hasn't actually been run in its current form. Want to coordinate the release of `0.0.3` before running this.