### PR TITLE
Deploy assets to correct location

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -123,6 +123,8 @@ git archive --format=tar "$VERSION" \
 
 cd "$REPOSITORY"
 cp "tags/$VERSION/readme.txt" trunk/readme.txt
+mv "tags/$VERSION/assets/icon-*" assets/
+# mv "tags/$VERSION/assets/banner-*" assets/
 
 if [[ "$DRY_RUN" = "true" ]]; then
   svn status


### PR DESCRIPTION
For some reason, WP has a top-level folder in the SVN repo that needs the icon and banner assets