### PR TITLE
Integration settings link ECI-514

### DIFF
--- a/drip.php
+++ b/drip.php
@@ -6,7 +6,7 @@
  */
 
 /*
-Plugin Name: Drip
+Plugin Name: Drip for WooCommerce
 Plugin URI: https://github.com/DripEmail/drip-woocommerce
 Description: A WordPress plugin to connect to Drip's WooCommerce integration
 Version: 0.0.3
@@ -25,6 +25,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	require_once __DIR__ . '/src/class-drip-woocommerce-view-events.php';
 	require_once __DIR__ . '/src/class-drip-woocommerce-version.php';
 	require_once __DIR__ . '/src/class-drip-woocommerce-customer-identify.php';
+	require_once __DIR__ . '/src/class-drip-woocommerce-plugin-view.php';
 
 	Drip_Woocommerce_Settings::init();
 	Drip_Woocommerce_Snippet::init();
@@ -32,4 +33,5 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	Drip_Woocommerce_View_Events::init();
 	Drip_Woocommerce_Version::init();
 	Drip_Woocommerce_Customer_Identify::init();
+	Drip_Woocommerce_Plugin_View::init();
 }

--- a/src/class-drip-woocommerce-plugin-view.php
+++ b/src/class-drip-woocommerce-plugin-view.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Plugin deactivation message
+ *
+ * @package Drip_Woocommerce
+ */
+
+defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
+
+/**
+ * Plugin deactivation message
+ */
+class Drip_Woocommerce_Plugin_View {
+	/**
+	 * Set up component
+	 */
+	public static function init() {
+		$component = new self();
+		$component->setup_actions();
+	}
+
+	/**
+	 * Register deactivation hook
+	 */
+	public function setup_actions() {
+		add_filter( 'plugin_action_links', array( $this, 'callback_plugin_action_links' ), 10, 2 );
+	}
+
+	/**
+	 * Callback for plugin_action_links
+	 *
+	 * @param array $actions The actions for this plugin.
+	 * @param array $plugin_file The files in the plugin.
+	 */
+	public function callback_plugin_action_links( $actions, $plugin_file ) {
+		$is_this_plugin = in_array( $plugin_file, array( 'drip/drip.php' ), true );
+		if ( $is_this_plugin ) {
+			array_unshift( $actions, $this->integrations_url() );
+		}
+		return $actions;
+	}
+
+	/**
+	 * The URL for the integration page
+	 *
+	 * Directs to the specific account id if we know it.
+	 */
+	private function integrations_url() {
+		$account_id      = WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::ACCOUNT_ID_KEY );
+		$account_segment = '';
+		if ( ! empty( $account_id ) ) {
+			$account_segment = "${account_id}/";
+		}
+		return "<a href=\"https://www.getdrip.com/${$account_segment}integrations/drip_woocommerce\">Integration Settings</a>";
+	}
+}


### PR DESCRIPTION
Add a link to the integration page from the plugin listing.
<img width="696" alt="Screen Shot 2020-03-13 at 4 02 56 PM" src="https://user-images.githubusercontent.com/1298231/76661338-2c642500-6549-11ea-9a03-909bdc41b3d6.png">
The link is to the generic account id integration page if we don't have an account id and the specific account id page if we do.

Goal of this is to make it even a little more clear that this other page exists, so hopefully people don't get confused.


Oh, and change the name inside the plugin to "Drip for WooCommerce" for consistency.