### PR TITLE
Don't re-add readme.txt to svn trunk

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -132,6 +132,6 @@ mv tags/$VERSION/assets/icon-* assets/
 if [[ "$DRY_RUN" = "true" ]]; then
   svn status
 else
-  svn add trunk/readme.txt "tags/$VERSION"
+  svn add "tags/$VERSION"
   svn commit -m "Publish version $VERSION" --username getdrip
 fi


### PR DESCRIPTION
SVN isn't like git. Don't re-add the readme.txt to trunk once it already exists.