### PR TITLE
Update required versions

### DIFF
--- a/drip.php
+++ b/drip.php
@@ -13,6 +13,9 @@ Version: 0.0.5
 Author: Drip
 Author URI: https://www.drip.com/
 License: GPLv2
+
+WC requires at least: 3.0
+WC tested up to: 4.0
 */
 
 defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getdrip
 Tags: woocommerce, drip, ecrm, email marketing automation
 Requires at least: 4.6
-Tested up to: 5.3
+Tested up to: 5.4
 Stable tag: 0.0.5
 Requires PHP: 5.6
 License: GPLv2


### PR DESCRIPTION
We can indicate which versions of WooCommerce we support.

Also, WP 5.4 is out, so we should indicate support of that.