### PR TITLE
Remove json & base64 encoding of cart payloads

### DIFF
--- a/devtools_wp/cypress/integration/CartInteractions/steps.js
+++ b/devtools_wp/cypress/integration/CartInteractions/steps.js
@@ -127,7 +127,7 @@ Then('I get sent a webhook with visitor_uuid', () => {
 
     cy.wrap(validateRequests(recordedRequests)).then(function (body) {
       expect(body.action).to.eq('wc_drip_woocommerce_cart_event')
-      const event = JSON.parse(decodeBase64(body.arg))
+      const event = body.arg
       cy.wrap([
         'event_action',
         'session',
@@ -227,7 +227,7 @@ Then('I get sent a webhook with a cart session ID', () => {
     }
   )).then(function (recordedRequests) {
     const body = validateRequests(recordedRequests)
-    const event = JSON.parse(decodeBase64(body.arg))
+    const event = body.arg
     expect(event.session).to.have.lengthOf(64)
     cy.wrap(event.session).as('lastCartSession')
   })
@@ -245,7 +245,7 @@ Then('I get sent a webhook with a different cart session ID', () => {
   )).then(function (recordedRequests) {
     const body = validateRequests(recordedRequests)
     cy.wrap(this.lastCartSession).then(function(lastCartSession) {
-      const event = JSON.parse(decodeBase64(body.arg))
+      const event = body.arg
       expect(lastCartSession).to.have.lengthOf(64)
       expect(event.session).to.have.lengthOf(64)
       expect(event.session).to.not.eq(lastCartSession)
@@ -265,7 +265,7 @@ Then('I get sent a webhook with the same cart session ID', () => {
     }
   )).then(function (recordedRequests) {
     const body = validateRequests(recordedRequests)
-    const event = JSON.parse(decodeBase64(body.arg))
+    const event = body.arg
     cy.wrap(this.lastCartSession).then(function(lastCartSession) {
       expect(lastCartSession).to.have.lengthOf(64)
       expect(event.session).to.have.lengthOf(64)
@@ -299,8 +299,8 @@ const validateRequests = function (requests) {
 
 const validateRequestBody = function (body) {
   expect(body.action).to.eq('wc_drip_woocommerce_cart_event')
-  console.log(decodeBase64(body.arg))
-  const event = JSON.parse(decodeBase64(body.arg))
+  console.log(body.arg)
+  const event = body.arg
   cy.wrap([
     'event_action',
     'session',
@@ -329,36 +329,20 @@ const validateRequestBody = function (body) {
 const validateMyFairWidget = function (event, quantity = 1) {
   const product = findWidget(event.cart_data)
   expect(product.product_id.toString()).to.eq('6') // only works because we reset the entire db with each scenerio
-  expect(product.product_variant_id.toString()).to.eq('6')
-  expect(product.sku).to.eq('fair-widg-12345')
-  expect(product.name).to.eq('My Fair Widget')
+  expect(product.product_variant_id.toString()).to.eq('0')
   expect(product.quantity).to.eq(quantity)
-  expect(product.price.toString()).to.eq('10.99')
   expect(product.taxes.toString()).to.eq('0')
   expect(product.total.toString()).to.eq(`${10.99 * quantity}`)
-  expect(product.product_url).to.eq('http://localhost:3007/?product=fair-widget')
-  expect(product.image_url).contains('<img')
-  expect(product.image_url).contains('http://localhost:3007/wp-content/plugins/woocommerce/assets/images/placeholder.png')
-  expect(product.categories).to.have.lengthOf(1)
-  expect(product.categories[0]).to.eq('my fair category')
   return product
 }
 
 const validateMyFairGizmo = function (event, quantity = 1) {
   const product = findGizmo(event.cart_data)
   expect(product.product_id.toString()).to.eq('7') // only works because we reset the entire db with each scenerio
-  expect(product.product_variant_id.toString()).to.eq('7')
-  expect(product.sku).to.eq('fair-gzmo-67890')
-  expect(product.name).to.eq('My Fair Gizmo')
+  expect(product.product_variant_id.toString()).to.eq('0')
   expect(product.quantity).to.eq(quantity)
-  expect(product.price.toString()).to.eq('11.11')
   expect(product.taxes.toString()).to.eq('0')
   expect(product.total.toString()).to.eq(`${11.11 * quantity}`)
-  expect(product.product_url).to.eq('http://localhost:3007/?product=fair-gizmo')
-  expect(product.image_url).contains('<img')
-  expect(product.image_url).contains('http://localhost:3007/wp-content/plugins/woocommerce/assets/images/placeholder.png')
-  expect(product.categories).to.have.lengthOf(1)
-  expect(product.categories[0]).to.eq('my fair category')
   return product
 }
 
@@ -376,5 +360,3 @@ const findProduct = function(product_id, cart_data) {
   }
   return cart_data[Object.keys(cart_data)[1]]
 }
-
-const decodeBase64 = function(encoded_string) { return atob(encoded_string); }

--- a/src/class-drip-woocommerce-cart-event-product.php
+++ b/src/class-drip-woocommerce-cart-event-product.php
@@ -26,34 +26,6 @@ class Drip_Woocommerce_Cart_Event_Product {
 	public $product_variant_id;
 
 	/**
-	 * SKU
-	 *
-	 * @var string
-	 */
-	public $sku;
-
-	/**
-	 * Name
-	 *
-	 * @var string
-	 */
-	public $name;
-
-	/**
-	 * Short Description
-	 *
-	 * @var string
-	 */
-	public $short_description;
-
-	/**
-	 * Price
-	 *
-	 * @var float
-	 */
-	public $price;
-
-	/**
 	 * Taxes
 	 *
 	 * @var float
@@ -73,25 +45,4 @@ class Drip_Woocommerce_Cart_Event_Product {
 	 * @var int
 	 */
 	public $quantity;
-
-	/**
-	 * Product URL
-	 *
-	 * @var string
-	 */
-	public $product_url;
-
-	/**
-	 * Image URL
-	 *
-	 * @var string
-	 */
-	public $image_url;
-
-	/**
-	 * Categories
-	 *
-	 * @var array
-	 */
-	public $categories = array();
 }

--- a/src/class-drip-woocommerce-cart-events.php
+++ b/src/class-drip-woocommerce-cart-events.php
@@ -51,11 +51,11 @@ class Drip_Woocommerce_Cart_Events {
 		foreach ( $cart_contents as $product_id => $cart_item_info ) {
 			$product_event_data = $this->product_event_data( $cart_item_info );
 			if ( $product_event_data ) {
-				$event->cart_data[ $product_id ] = $product_event_data;
+				$event->cart_data[] = $product_event_data;
 			}
 		}
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		do_action( 'wc_drip_woocommerce_cart_event', base64_encode( wp_json_encode( $event ) ) );
+		do_action( 'wc_drip_woocommerce_cart_event', $event );
 
 		if ( WC()->cart->is_empty() ) {
 			$this->remove_drip_cart_session_id();
@@ -71,9 +71,9 @@ class Drip_Woocommerce_Cart_Events {
 		$event               = new Drip_Woocommerce_Cart_Event();
 		$event->event_action = self::CART_UPDATED_ACTION; // TODO: we can trap cart created events if we have to generate a new cart session id.
 		if ( $this->user_invalid() ) {
-				$event->visitor_uuid = $this->find_drip_visitor_uuid();
+			$event->visitor_uuid = $this->find_drip_visitor_uuid();
 		} else {
-				$event->customer_email = wp_get_current_user()->user_email;
+			$event->customer_email = wp_get_current_user()->user_email;
 		}
 		$event->session         = $this->drip_cart_session_id();
 		$event->grand_total     = WC()->cart->get_total( 'drip_woocommerce' );
@@ -100,17 +100,10 @@ class Drip_Woocommerce_Cart_Events {
 
 		$cart_event_product                     = new Drip_Woocommerce_Cart_Event_Product();
 		$cart_event_product->product_id         = $cart_item_info['product_id'];
-		$cart_event_product->product_variant_id = $product_key;
-		$cart_event_product->sku                = $product_data->get_sku( 'drip_woocommerce' );
-		$cart_event_product->name               = $product_data->get_name( 'drip_woocommerce' );
-		$cart_event_product->short_description  = $product_data->get_short_description( 'drip_woocommerce' );
-		$cart_event_product->price              = $product_data->get_price( 'drip_woocommerce' );
+		$cart_event_product->product_variant_id = $cart_item_info['variation_id'];
 		$cart_event_product->taxes              = $cart_item_info['line_tax'];
 		$cart_event_product->total              = $cart_item_info['line_total'];
 		$cart_event_product->quantity           = $cart_item_info['quantity'];
-		$cart_event_product->product_url        = $product_data->get_permalink();
-		$cart_event_product->image_url          = $product_data->get_image( 'woocommerce_single', array(), true );
-		$cart_event_product->categories         = $this->product_categories( $product_data );
 
 		return $cart_event_product;
 	}


### PR DESCRIPTION
Part of: https://dripcom.atlassian.net/browse/ECI-768

Needs: https://github.com/DripEmail/woo/pull/182

Removes base64 encoding of cart events and strips down some of the data sent over to the service.

After these changes I was able to get 96 items into a cart.