### PR TITLE
Leave unsubscribed when identifying

### DIFF
--- a/src/customer_identify.js
+++ b/src/customer_identify.js
@@ -1,5 +1,5 @@
 (function(dwid) {
   const _q = (typeof _dcq !== 'undefined' && _dcq !== null) ? _dcq : [];
   const _d = (typeof dwid !== 'undefined' && dwid !== null) ? dwid : {found: false};
-  if(_d.found) { _q.push(["identify", { email: _d.id }]); }
+  if(_d.found) { _q.push(["identify", { email: _d.id, drip_unknown_status: true }]); }
 })(drip_woocommerce_identify_data);


### PR DESCRIPTION
Co-authored-by: Tianna Avery <tianna.avery@drip.com>
Co-authored-by: Ian Nance <ian.nance@drip.com>

Right now, whenever someone places an order, we identify them. For historical reasons, someone identified is also subscribed unless we explicitly tell Drip to not. Due to an oversight, we missed this and are subscribing everyone who places an order, regardless of whether they checked the box to subscribe.

This fix will cause Drip to not auto-subscribe just by placing an order.