### PR TITLE
ECI-827 checked by default marketing option

### DIFF
--- a/devtools_wp/cypress/integration/CheckoutAcceptingMarketing.feature
+++ b/devtools_wp/cypress/integration/CheckoutAcceptingMarketing.feature
@@ -17,7 +17,7 @@ Feature: Checkout Accepting Marketing
       And I have a logged in user
     When I add it to a cart
      And I start to check out
-    Then The marketing checkbox is present
+    Then The marketing checkbox is present and unchecked
 
   Scenario: Marketing checkbox shows up if using default opt-in
     Given I have Drip configured
@@ -26,7 +26,7 @@ Feature: Checkout Accepting Marketing
       And I have a product
     When I add it to a cart
       And I start to check out
-    Then The marketing checkbox is present
+    Then The marketing checkbox is present and unchecked
 
   Scenario: Marketing checkbox doesn't show up if opted out
     Given I have Drip configured
@@ -46,7 +46,17 @@ Feature: Checkout Accepting Marketing
       And I have opted into showing email marketing signup at checkout
     When I add it to a cart
       And I start to check out
-    Then The marketing checkbox is present
+    Then The marketing checkbox is present and unchecked
+
+  Scenario: Marketing checkbox shows up if opted in by default
+    Given I have Drip configured
+      And I am logged in as an admin user
+      And I have created an accepts marketing webhook
+      And I have a product
+      And I have opted into showing email marketing signup by default at checkout
+    When I add it to a cart
+      And I start to check out
+    Then The marketing checkbox is present and checked
 
   Scenario: Accepting marketing during checkout
     Given I have Drip configured

--- a/devtools_wp/cypress/integration/CheckoutAcceptingMarketing/steps.js
+++ b/devtools_wp/cypress/integration/CheckoutAcceptingMarketing/steps.js
@@ -35,6 +35,13 @@ Given('I have opted into showing email marketing signup at checkout', () => {
   cy.contains('Save changes').click()
 })
 
+Given('I have opted into showing email marketing signup by default at checkout', () => {
+  cy.visit('/wp-admin/admin.php?page=wc-settings&tab=settings_drip');
+  cy.wrap(Mockclient.reset());
+  cy.get('input#drip_enable_signup_default[type="checkbox"]').check();
+  cy.contains('Save changes').click()
+})
+
 Then('I start to check out', () => {
   cy.route('POST', '/?wc-ajax=update_order_review').as('updateOrderReview')
 
@@ -92,8 +99,14 @@ Then('The marketing checkbox is not present', () => {
   cy.get('input#drip_woocommerce_accepts_marketing[type="checkbox"]').should('have.length', 0)
 })
 
-Then('The marketing checkbox is present', () => {
+Then('The marketing checkbox is present and unchecked', () => {
   cy.get('input#drip_woocommerce_accepts_marketing[type="checkbox"]').should('have.length', 1)
+  cy.get('input#drip_woocommerce_accepts_marketing[type="checkbox"]').should("not.be.checked")
+})
+
+Then('The marketing checkbox is present and checked', () => {
+  cy.get('input#drip_woocommerce_accepts_marketing[type="checkbox"]').should('have.length', 1)
+  cy.get('input#drip_woocommerce_accepts_marketing[type="checkbox"]').should("be.checked")
 })
 
 const validateRequests = function (requests) {

--- a/src/class-drip-woocommerce-checkout-marketing-confirmation.php
+++ b/src/class-drip-woocommerce-checkout-marketing-confirmation.php
@@ -52,7 +52,7 @@ class Drip_Woocommerce_Checkout_Marketing_Confirmation {
 		// Drip_Woocommerce_Settings::MARKETING_CONFIG_TEXT, so...
 		// ...we have to guard against an empty return here.
 		// phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
-		$label = WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::MARKETING_CONFIG_TEXT ) ?: 'Send me news, announcements, and discounts.';
+		$label   = WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::MARKETING_CONFIG_TEXT ) ?: 'Send me news, announcements, and discounts.';
 		$checked = WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::DEFAULT_MARKETING_CONFIG_KEY ) === 'yes' ? 1 : 0;
 		woocommerce_form_field(
 			self::FIELD_NAME,

--- a/src/class-drip-woocommerce-checkout-marketing-confirmation.php
+++ b/src/class-drip-woocommerce-checkout-marketing-confirmation.php
@@ -40,7 +40,7 @@ class Drip_Woocommerce_Checkout_Marketing_Confirmation {
 	 * Callback for woocommerce_review_order_before_submit
 	 */
 	public function callback_review_order() {
-		if ( $this->drip_not_integrated() || WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::MARKETING_CONFIG_KEY ) === 'no' ) {
+		if ( $this->drip_not_integrated() || (WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::MARKETING_CONFIG_KEY ) === 'no' && WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::DEFAULT_MARKETING_CONFIG_KEY) === 'no') ) {
 			return;
 		}
 
@@ -53,12 +53,14 @@ class Drip_Woocommerce_Checkout_Marketing_Confirmation {
 		// ...we have to guard against an empty return here.
 		// phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 		$label = WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::MARKETING_CONFIG_TEXT ) ?: 'Send me news, announcements, and discounts.';
+		$checked = WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::DEFAULT_MARKETING_CONFIG_KEY ) === 'yes' ? 1 : 0;
 		woocommerce_form_field(
 			self::FIELD_NAME,
 			array(
 				'type'  => 'checkbox',
 				'label' => $label,
-			)
+			),
+			$checked
 		);
 	}
 

--- a/src/class-drip-woocommerce-checkout-marketing-confirmation.php
+++ b/src/class-drip-woocommerce-checkout-marketing-confirmation.php
@@ -40,7 +40,7 @@ class Drip_Woocommerce_Checkout_Marketing_Confirmation {
 	 * Callback for woocommerce_review_order_before_submit
 	 */
 	public function callback_review_order() {
-		if ( $this->drip_not_integrated() || (WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::MARKETING_CONFIG_KEY ) === 'no' && WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::DEFAULT_MARKETING_CONFIG_KEY) === 'no') ) {
+		if ( $this->drip_not_integrated() || ( WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::MARKETING_CONFIG_KEY ) === 'no' && WC_Admin_Settings::get_option( Drip_Woocommerce_Settings::DEFAULT_MARKETING_CONFIG_KEY ) === 'no' ) ) {
 			return;
 		}
 

--- a/src/class-drip-woocommerce-settings.php
+++ b/src/class-drip-woocommerce-settings.php
@@ -147,9 +147,9 @@ class Drip_Woocommerce_Settings {
 			),
 			self::DEFAULT_MARKETING_CONFIG_KEY => array(
 				'id'                => self::DEFAULT_MARKETING_CONFIG_KEY,
-				'name'              => __( 'Email Marketing checked by default', self::NAME ),
+				'name'              => __( 'Pre-Select Email Marketing Checkbox', self::NAME ),
 				'type'              => 'checkbox',
-				'desc'              => __( 'Show a sign up option at checkout, checked by default.', self::NAME ),
+				'desc'              => __( '<a href="https://my.drip.com/search?query=gdpr" target="_blank">review GDPR</a>', self::NAME ),
 				'default'           => 'no',
 				'custom_attributes' => $drip_settings->custom_attributes(),
 			),

--- a/src/class-drip-woocommerce-settings.php
+++ b/src/class-drip-woocommerce-settings.php
@@ -11,10 +11,11 @@ defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
  * Management for plugin settings
  */
 class Drip_Woocommerce_Settings {
-	const NAME                  = 'woocommerce-settings-drip';
-	const ACCOUNT_ID_KEY        = 'account_id';
-	const MARKETING_CONFIG_KEY  = 'drip_enable_signup';
-	const MARKETING_CONFIG_TEXT = 'drip_signup_text';
+	const NAME                          = 'woocommerce-settings-drip';
+	const ACCOUNT_ID_KEY                = 'account_id';
+	const MARKETING_CONFIG_KEY          = 'drip_enable_signup';
+	const MARKETING_CONFIG_TEXT         = 'drip_signup_text';
+	const DEFAULT_MARKETING_CONFIG_KEY  = 'drip_enable_signup_default';
 
 	/**
 	 * Bootstraps the class and hooks required actions & filters.
@@ -89,6 +90,15 @@ class Drip_Woocommerce_Settings {
 		);
 
 		$settings[] = array(
+			'id'          => self::DEFAULT_MARKETING_CONFIG_KEY,
+			'option_key'  => self::DEFAULT_MARKETING_CONFIG_KEY,
+			'label'       => __( 'Email Marketing checked by default', self::NAME ),
+			'description' => __( 'If checked, includes an sign up option during checkout that is checked by default.', self::NAME ),
+			'default'     => 'no',
+			'type'        => 'checkbox',
+		);
+
+		$settings[] = array(
 			'id'          => self::MARKETING_CONFIG_TEXT,
 			'option_key'  => self::MARKETING_CONFIG_TEXT,
 			'label'       => __( 'Default Text', self::NAME ),
@@ -135,6 +145,15 @@ class Drip_Woocommerce_Settings {
 				'default'           => 'yes',
 				'custom_attributes' => $drip_settings->custom_attributes(),
 			),
+			self::DEFAULT_MARKETING_CONFIG_KEY  => array(
+				'id'                => self::DEFAULT_MARKETING_CONFIG_KEY,
+				'name'              => __( 'Email Marketing checked by default', self::NAME ),
+				'type'              => 'checkbox',
+				'desc'              => __( 'Show a sign up option at checkout, checked by default.', self::NAME ),
+				'default'           => 'no',
+				'custom_attributes' => $drip_settings->custom_attributes(),
+			),
+
 			self::MARKETING_CONFIG_TEXT => array(
 				'id'                => self::MARKETING_CONFIG_TEXT,
 				'name'              => __( 'Default Text', self::NAME ),

--- a/src/class-drip-woocommerce-settings.php
+++ b/src/class-drip-woocommerce-settings.php
@@ -11,11 +11,11 @@ defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
  * Management for plugin settings
  */
 class Drip_Woocommerce_Settings {
-	const NAME                          = 'woocommerce-settings-drip';
-	const ACCOUNT_ID_KEY                = 'account_id';
-	const MARKETING_CONFIG_KEY          = 'drip_enable_signup';
-	const MARKETING_CONFIG_TEXT         = 'drip_signup_text';
-	const DEFAULT_MARKETING_CONFIG_KEY  = 'drip_enable_signup_default';
+	const NAME                         = 'woocommerce-settings-drip';
+	const ACCOUNT_ID_KEY               = 'account_id';
+	const MARKETING_CONFIG_KEY         = 'drip_enable_signup';
+	const MARKETING_CONFIG_TEXT        = 'drip_signup_text';
+	const DEFAULT_MARKETING_CONFIG_KEY = 'drip_enable_signup_default';
 
 	/**
 	 * Bootstraps the class and hooks required actions & filters.
@@ -124,20 +124,20 @@ class Drip_Woocommerce_Settings {
 	public static function get_settings() {
 		$drip_settings = new Drip_Woocommerce_Settings();
 		$settings      = array(
-			'section_title'             => array(
+			'section_title'                    => array(
 				'id'   => 'wc_settings_drip_section_title',
 				'name' => __( 'Drip', self::NAME ),
 				'type' => 'title',
 				'desc' => '',
 			),
-			self::ACCOUNT_ID_KEY        => array(
+			self::ACCOUNT_ID_KEY               => array(
 				'id'                => self::ACCOUNT_ID_KEY,
 				'name'              => __( 'Account ID', self::NAME ),
 				'type'              => 'number',
 				'desc'              => __( 'Drip Account ID is populated when your store is successfully connected to Drip.', self::NAME ),
 				'custom_attributes' => array( 'readonly' => 'readonly' ),
 			),
-			self::MARKETING_CONFIG_KEY  => array(
+			self::MARKETING_CONFIG_KEY         => array(
 				'id'                => self::MARKETING_CONFIG_KEY,
 				'name'              => __( 'Email Marketing', self::NAME ),
 				'type'              => 'checkbox',
@@ -145,7 +145,7 @@ class Drip_Woocommerce_Settings {
 				'default'           => 'yes',
 				'custom_attributes' => $drip_settings->custom_attributes(),
 			),
-			self::DEFAULT_MARKETING_CONFIG_KEY  => array(
+			self::DEFAULT_MARKETING_CONFIG_KEY => array(
 				'id'                => self::DEFAULT_MARKETING_CONFIG_KEY,
 				'name'              => __( 'Email Marketing checked by default', self::NAME ),
 				'type'              => 'checkbox',
@@ -154,7 +154,7 @@ class Drip_Woocommerce_Settings {
 				'custom_attributes' => $drip_settings->custom_attributes(),
 			),
 
-			self::MARKETING_CONFIG_TEXT => array(
+			self::MARKETING_CONFIG_TEXT        => array(
 				'id'                => self::MARKETING_CONFIG_TEXT,
 				'name'              => __( 'Default Text', self::NAME ),
 				'type'              => 'text',
@@ -162,7 +162,7 @@ class Drip_Woocommerce_Settings {
 				'default'           => __( 'Send me news, announcements, and discounts.', self::NAME ),
 				'custom_attributes' => $drip_settings->custom_attributes(),
 			),
-			'section_end'               => array(
+			'section_end'                      => array(
 				'type' => 'sectionend',
 				'id'   => 'wc_settings_drip_section_end',
 			),

--- a/src/class-drip-woocommerce-settings.php
+++ b/src/class-drip-woocommerce-settings.php
@@ -149,7 +149,7 @@ class Drip_Woocommerce_Settings {
 				'id'                => self::DEFAULT_MARKETING_CONFIG_KEY,
 				'name'              => __( 'Pre-Select Email Marketing Checkbox', self::NAME ),
 				'type'              => 'checkbox',
-				'desc'              => __( '<a href="https://my.drip.com/search?query=gdpr" target="_blank">review GDPR</a>', self::NAME ),
+				'desc'              => __( '<a href="https://my.drip.com/search?query=gdpr" target="_blank">Selecting may have GDPR implications</a>', self::NAME ),
 				'default'           => 'no',
 				'custom_attributes' => $drip_settings->custom_attributes(),
 			),


### PR DESCRIPTION
Addresses: https://dripcom.atlassian.net/browse/ECI-827

Adds a new Drip setting. When checked, the accept marketing checkbox will show up on the checkout page and be checked by default.

We will need a name and a description for this new setting. This screenshot shows the current setting "Email Marketing". I tacked "checked by default" on to the new setting for now, but presumably we'll want something to better help our customers justify this thing to themselves.

<img width="741" alt="Screen Shot 2020-07-08 at 2 26 50 PM" src="https://user-images.githubusercontent.com/5335496/86972426-c585ff80-c127-11ea-9c03-4e8ad24e08af.png">
