### PR TITLE
ECI-960 image_id bug fix

### DIFF
--- a/devtools_wp/cypress/integration/OrderInteractions/steps.js
+++ b/devtools_wp/cypress/integration/OrderInteractions/steps.js
@@ -32,7 +32,7 @@ Then('I add a widget to my cart', () => {
       expect(call).to.have.lengthOf(2)
       expect(call[0]).to.eq("identify")
       const identify_data = call[1]
-      expect(Object.keys(identify_data)).to.have.lengthOf(1)
+      expect(Object.keys(identify_data)).to.have.lengthOf(2)
       expect(identify_data.email).to.eq('eliza.doolittle@example.com')
     })
   })

--- a/devtools_wp/cypress/integration/ProductViewInteractions/steps.js
+++ b/devtools_wp/cypress/integration/ProductViewInteractions/steps.js
@@ -20,7 +20,7 @@ Then("the page includes a Drip JS API call", () => {
     expect(product.name).to.eq('My Fair Widget')
     expect(product.price.toString()).to.eq('1099')
     expect(product.product_url).to.eq('http://localhost:3007/?product=fair-widget')
-    expect(product.image_url).to.eq('')
+    expect(product.image_url).to.have.string('foundation_widget_simple-black_512x512-150x150.png')
     expect(product.currency).to.eq('GBP')
     expect(product.categories).to.eq('my fair category')
   })

--- a/devtools_wp/cypress/integration/common/products.js
+++ b/devtools_wp/cypress/integration/common/products.js
@@ -11,6 +11,7 @@ Given('I have a product', () => {
     'slug': 'fair-widget',
     'regular_price': 10.99,
     'sku': 'fair-widg-12345',
-    'categories': '[{"id":16}]'
+    'categories': '[{"id":16}]',
+    'images': '[{"id":5}]'
   })
 })

--- a/devtools_wp/setup.sh
+++ b/devtools_wp/setup.sh
@@ -16,6 +16,7 @@ cd /var/www/html/ && \
 /usr/local/bin/wp core install --url="http://localhost:$port" --title="drip_woocommerce_test" --admin_user="drip" --admin_email="drip@example.com" --admin_password="abc1234567890" --skip-email && \
 /usr/local/bin/wp plugin activate woocommerce && \
 /usr/local/bin/wp plugin activate drip; \
+/usr/local/bin/wp media import https://iconsetc.com/icons-watermarks/simple-black/foundation/foundation_widget/foundation_widget_simple-black_512x512.png
 CART_PAGE_ID=\$(/usr/local/bin/wp post create --post_type=page --post_author="drip" --post_title="My Fair Cart" --post_name="My Fair Cart" --post_content="[woocommerce_cart]" --post_status="publish" --porcelain) && \
 /usr/local/bin/wp option set woocommerce_cart_page_id \$CART_PAGE_ID --autoload='yes'; \
 CHKOUT_PAGE_ID=\$(/usr/local/bin/wp post create --post_type=page --post_author="drip" --post_title="My Fair Checkout" --post_name="My Fair Checkout" --post_content="[woocommerce_checkout]" --post_status="publish" --porcelain) && \
@@ -50,6 +51,7 @@ fi
 SCRIPT
 )
 
+docker-compose exec -T -u root web /bin/bash -c "chown www-data wp-content"
 docker-compose exec -T -u www-data web /bin/bash -c "$woocommerce_setup_script"
 docker-compose exec -T -u root web /bin/bash -c "$(cat install-composer.sh)"
 docker-compose exec -T -u root web /bin/bash -c "$update_bashrc_script"

--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -32,7 +32,7 @@ class Drip_Woocommerce_View_Events {
 	public function drip_woocommerce_viewed_product() {
 		wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), '1', true );
 		$product            = wc_get_product();
-		$image_id = $product->get_image_id();
+		$image_id           = $product->get_image_id();
 		$product_attributes = array(
 			'product_id'         => $product->get_id( 'drip_woocommerce' ),
 			'product_variant_id' => $product->get_variation_id( 'drip_woocommerce' ),

--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -32,6 +32,7 @@ class Drip_Woocommerce_View_Events {
 	public function drip_woocommerce_viewed_product() {
 		wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), '1', true );
 		$product            = wc_get_product();
+		$image_id = $product->get_image_id();
 		$product_attributes = array(
 			'product_id'         => $product->get_id( 'drip_woocommerce' ),
 			'product_variant_id' => $product->get_variation_id( 'drip_woocommerce' ),
@@ -41,7 +42,7 @@ class Drip_Woocommerce_View_Events {
 			'product_url'        => $product->get_permalink(),
 			'currency'           => get_option( 'woocommerce_currency' ),
 			'categories'         => $this->product_categories( $product ),
-			'image_id'           => $product->get_image_id(),
+			'image_id'           => $image_id,
 			'image_url'          => wp_get_attachment_image_url( $image_id ),
 		);
 


### PR DESCRIPTION
Addresses: https://dripcom.atlassian.net/browse/ECI-960

From what I can tell, `image_url` isn't working at all because we have an undefined variable https://github.com/DripEmail/drip-woocommerce/blob/4d50944e7265f5b5d3a4c44ba58ebedeffa23a8c/src/class-drip-woocommerce-view-events.php#L45

I looked in a couple accounts, and "Viewed a product" events are being recorded, but that `image_url` value is empty in the properties. I'm not sure how we are recovering from that error in most cases. The customer on the ticket reports that this breaks their site, but I'm not sure why that is happening to them and not to others.

This fixes that variable and adds an image to our tests to confirm behavior. 