### PR TITLE
Deprecated product get variation

### DIFF
--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -34,8 +34,8 @@ class Drip_Woocommerce_View_Events {
 		$product            = wc_get_product();
 		$image_id           = $product->get_image_id();
 		$product_attributes = array(
-			'product_id'         => $product->get_id( 'drip_woocommerce' ),
-			'product_variant_id' => $product->get_variation_id( 'drip_woocommerce' ),
+			'product_id'         => $product->get_id(),
+			'product_variant_id' => $product->get_variation_id(),
 			'sku'                => $product->get_sku( 'drip_woocommerce' ),
 			'name'               => $product->get_name( 'drip_woocommerce' ),
 			'price'              => $product->get_price( 'drip_woocommerce' ) * 100,

--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -35,7 +35,7 @@ class Drip_Woocommerce_View_Events {
 		$image_id           = $product->get_image_id();
 		$product_attributes = array(
 			'product_id'         => $product->get_id(),
-			'product_variant_id' => $product->get_variation_id(),
+			'product_variant_id' => $product->get_id(),
 			'sku'                => $product->get_sku( 'drip_woocommerce' ),
 			'name'               => $product->get_name( 'drip_woocommerce' ),
 			'price'              => $product->get_price( 'drip_woocommerce' ) * 100,


### PR DESCRIPTION
Deprecated $product->get_variation_id()

From /woocommerce/includes/legacy/abstract-wc-legacy-product.php:463
```
/**
 * Get variation ID.
 *
 * @deprecated 3.0.0
 * @return int
 */
public function get_variation_id() {
	wc_deprecated_function( 'WC_Product::get_variation_id', '3.0', 'WC_Product::get_id(). It will always be the variation ID if this is a variation.' );
	return $this->get_id();
}
```