### PR TITLE
Handle empty prices

### DIFF
--- a/devtools_wp/cypress/integration/ProductViewInteractions.feature
+++ b/devtools_wp/cypress/integration/ProductViewInteractions.feature
@@ -6,3 +6,8 @@ Feature: Product View Interactions
     Given I have a product
     When I view a product
     Then the page includes a Drip JS API call
+
+  Scenario: I view a null-price product page
+    Given I have a null-price product
+    When I view a null-price product
+    Then the page includes a null-price Drip JS API call

--- a/devtools_wp/cypress/integration/ProductViewInteractions/steps.js
+++ b/devtools_wp/cypress/integration/ProductViewInteractions/steps.js
@@ -14,12 +14,37 @@ Then("the page includes a Drip JS API call", () => {
     expect(call[1]).to.eq("Viewed a product")
 
     const product = call[2]
-    expect(product.product_id.toString()).to.eq('13') // only works because we reset the entire db with each scenerio
-    expect(product.product_variant_id.toString()).to.eq('13')
+    expect(product.product_id.toString()).to.eq('12') // only works because we reset the entire db with each scenerio
+    expect(product.product_variant_id.toString()).to.eq('12')
     expect(product.sku).to.eq('fair-widg-12345')
     expect(product.name).to.eq('My Fair Widget')
     expect(product.price.toString()).to.eq('1099')
     expect(product.product_url).to.eq('http://localhost:3007/?product=fair-widget')
+    expect(product.currency).to.eq('GBP')
+    expect(product.categories).to.eq('my fair category')
+  })
+})
+
+Given('I view a null-price product', () => {
+    cy.visit('/?product=fair-widget-null')
+})
+
+Then("the page includes a null-price Drip JS API call", () => {
+  cy.window().then(function(win) {
+    expect(win._dcq).to.have.lengthOf(1)
+
+    const call = win._dcq[0]
+    expect(call).to.have.lengthOf(3)
+    expect(call[0]).to.eq("track")
+    expect(call[1]).to.eq("Viewed a product")
+
+    const product = call[2]
+    expect(product.product_id.toString()).to.eq('12') // only works because we reset the entire db with each scenerio
+    expect(product.product_variant_id.toString()).to.eq('12')
+    expect(product.sku).to.eq('fair-widg-12345-null')
+    expect(product.name).to.eq('My Fair Widget Null')
+    expect(product.price.toString()).to.eq('0')
+    expect(product.product_url).to.eq('http://localhost:3007/?product=fair-widget-null')
     expect(product.currency).to.eq('GBP')
     expect(product.categories).to.eq('my fair category')
   })

--- a/devtools_wp/cypress/integration/common/products.js
+++ b/devtools_wp/cypress/integration/common/products.js
@@ -14,3 +14,17 @@ Given('I have a product', () => {
     'categories': '[{"id":16}]'
   })
 })
+
+Given('I have a null-price product', () => {
+  cy.wpcliCreateProductCategory({
+    'porcelain': '',
+    'name': 'my fair category'
+  })
+
+  cy.wpcliCreateProduct({
+    'name': 'My Fair Widget Null',
+    'slug': 'fair-widget-null',
+    'sku': 'fair-widg-12345-null',
+    'categories': '[{"id":16}]'
+  })
+})

--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -31,9 +31,9 @@ class Drip_Woocommerce_View_Events {
 	 */
 	public function drip_woocommerce_viewed_product() {
 		wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), '1', true );
-		$product            				= wc_get_product();
-		$image_id           				= $product->get_image_id();
-		$product_price      				= $product->get_price();
+		$product                    = wc_get_product();
+		$image_id                   = $product->get_image_id();
+		$product_price              = $product->get_price();
 		$adjusted_product_price     = 0;
 		if (!empty($product_price)) {
 			$adjusted_product_price = ($product_price * 100);

--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -31,14 +31,19 @@ class Drip_Woocommerce_View_Events {
 	 */
 	public function drip_woocommerce_viewed_product() {
 		wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), '1', true );
-		$product            = wc_get_product();
-		$image_id           = $product->get_image_id();
+		$product            				= wc_get_product();
+		$image_id           				= $product->get_image_id();
+		$product_price      				= $product->get_price();
+		$adjusted_product_price     = 0;
+		if (!empty($product_price)) {
+			$adjusted_product_price = ($product_price * 100);
+		}
 		$product_attributes = array(
 			'product_id'         => $product->get_id(),
 			'product_variant_id' => $product->get_id(),
 			'sku'                => $product->get_sku( 'edit' ),
 			'name'               => $product->get_name( 'edit' ),
-			'price'              => $product->get_price( 'edit' ) * 100,
+			'price'              => $adjusted_product_price,
 			'product_url'        => $product->get_permalink(),
 			'currency'           => get_option( 'woocommerce_currency' ),
 			'categories'         => $this->product_categories( $product ),


### PR DESCRIPTION
Addresses: https://getdrip.slack.com/archives/CMLFRE81J/p1668724095746649

We've had some customers who've managed to set `null` prices on some products. Our plugin is breaking the page when that happens.

This updates to check for an empty price. When empty, we skip doing math on it set it to 0 for the API call to Drip.