### PR TITLE
[ECI-1896] Use php helper to detect product views

### DIFF
--- a/drip.php
+++ b/drip.php
@@ -9,7 +9,7 @@
 Plugin Name: Drip for WooCommerce
 Plugin URI: https://github.com/DripEmail/drip-woocommerce
 Description: A WordPress plugin to connect to Drip's WooCommerce integration
-Version: 1.1.5
+Version: 1.1.6
 Author: Drip
 Author URI: https://www.drip.com/
 License: GPLv2

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getdrip
 Tags: ecommerce, emailmarketing, marketingautomation, emailmarketingautomation, woocommerce, drip
 Requires at least: 4.6
 Tested up to: 6.2.2
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 Requires PHP: 5.6
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -47,7 +47,7 @@ Install the official Drip for WooCommerce plugin. See why thousands of ecommerce
 
 === Do you offer a free trial? ===
 
-Yes, we offer a free 14-day trial for new users. Sign up for a free trial today (no credit card needed): [https://www.getdrip.com/signup/basic](https://www.getdrip.com/signup/basic) 
+Yes, we offer a free 14-day trial for new users. Sign up for a free trial today (no credit card needed): [https://www.getdrip.com/signup/basic](https://www.getdrip.com/signup/basic)
 
 === How much does Drip cost? ===
 
@@ -73,6 +73,11 @@ The philosophy behind this plugin is to do as little as possible in it, and as m
 = NEXT =
 
 * Your change here!
+
+= 1.1.6 =
+
+* Use a more robust method for detecting product view events
+
 = 1.1.5 =
 
 * Fix bug when calling get_cart function before WP finishes loading

--- a/src/class-drip-woocommerce-view-events.php
+++ b/src/class-drip-woocommerce-view-events.php
@@ -22,12 +22,20 @@ class Drip_Woocommerce_View_Events {
 	/**
 	 * Start processing view actions
 	 */
-	public function setup_view_actions() {
-		add_action( 'woocommerce_after_single_product', array( $this, 'drip_woocommerce_viewed_product' ), 10 );
+	public function setup_view_actions()
+	{
+			add_action('wp_enqueue_scripts', array($this, 'conditionally_enqueue_scripts'));
+	}
+
+	public function conditionally_enqueue_scripts()
+	{
+			if (is_product()) {
+					$this->drip_woocommerce_viewed_product();
+			}
 	}
 
 	/**
-	 * Handler for woocommerce_after_single_product action
+	 * Handler for product viewed action
 	 */
 	public function drip_woocommerce_viewed_product() {
 		wp_register_script( 'Drip product view tracking', plugin_dir_url( __FILE__ ) . 'product_view_tracking.js', array(), '1', true );


### PR DESCRIPTION
One of our customers has disabled the `woocommerce_after_single_product` hook because it doesn't play well with some store theme behavior. This PR introduces what should be a more robust way of checking if the plugin is running on a product page.

Haven't been able to get the cypress tests running, but I've verified this with a local store and from reading through Woo API docs it seems like this `is_product` call should cover the behavior we're looking for.

Currently awaiting verification from the customer that this version of the plugin works for them in their live store.