### PR TITLE
ECI-1921 Implement Custom Script Type and Attributes in Drip's JS Snippet

### DIFF
--- a/devtools_wp/Dockerfile
+++ b/devtools_wp/Dockerfile
@@ -1,6 +1,6 @@
-FROM wordpress:6.2.2-php8.1-apache
+FROM wordpress:6.3.1-php8.1-apache
 
 RUN curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o /usr/local/bin/wp && chmod +x /usr/local/bin/wp
 RUN apt-get update && apt-get install -y less unzip vim wget vim-tiny net-tools
 
-RUN curl https://downloads.wordpress.org/plugin/woocommerce.7.8.2.zip -o /usr/src/woocommerce.zip && cd /usr/src/wordpress/wp-content/plugins && unzip /usr/src/woocommerce.zip
+RUN curl https://downloads.wordpress.org/plugin/woocommerce.8.2.0.zip -o /usr/src/woocommerce.zip && cd /usr/src/wordpress/wp-content/plugins && unzip /usr/src/woocommerce.zip

--- a/devtools_wp/cypress/integration/OrderInteractions/steps.js
+++ b/devtools_wp/cypress/integration/OrderInteractions/steps.js
@@ -24,7 +24,7 @@ Then('I add a widget to my cart', () => {
   })
 
   Then("the page includes a Drip JS API call", () => {
-    cy.get('script[src="http://localhost:3007/wp-content/plugins/drip/src/customer_identify.js?ver=6.2.2"]').should('have.length', 1)
+    cy.get('script[src="http://localhost:3007/wp-content/plugins/drip/src/customer_identify.js?ver=8.2.0"]').should('have.length', 1)
 
     cy.window().then(function(window) {
       expect(window._dcq).to.have.lengthOf(1)
@@ -38,7 +38,7 @@ Then('I add a widget to my cart', () => {
   })
 
   Then("the page does not make Drip JS API call", () => {
-    cy.get('script[src="http://localhost:3007/wp-content/plugins/drip/src/customer_identify.js?ver=6.2.2"]').should('have.length', 0)
+    cy.get('script[src="http://localhost:3007/wp-content/plugins/drip/src/customer_identify.js?ver=8.2.0"]').should('have.length', 0)
 
     cy.window().then(function(window) {
       expect(Object.keys(window)).to.not.include('_dcq')

--- a/devtools_wp/readme.md
+++ b/devtools_wp/readme.md
@@ -12,7 +12,7 @@ $ npm --version
 ```bash
 $ npm install
 ```
- - Spin up Docker and Magento, run setup.sh in the devtools_m1 directory
+ - Spin up Docker and Magento, run setup.sh in the devtools_wp directory
  ```aidl
 ./setup.sh
 ```

--- a/devtools_wp/readme.md
+++ b/devtools_wp/readme.md
@@ -12,7 +12,7 @@ $ npm --version
 ```bash
 $ npm install
 ```
- - Spin up Docker and Magento, run setup.sh in the devtools_wp directory
+ - Spin up Docker and WooCommerce, run setup.sh in the devtools_wp directory
  ```aidl
 ./setup.sh
 ```

--- a/drip.php
+++ b/drip.php
@@ -9,13 +9,13 @@
 Plugin Name: Drip for WooCommerce
 Plugin URI: https://github.com/DripEmail/drip-woocommerce
 Description: A WordPress plugin to connect to Drip's WooCommerce integration
-Version: 1.1.6
+Version: 1.1.7
 Author: Drip
 Author URI: https://www.drip.com/
 License: GPLv2
 
 WC requires at least: 3.0
-WC tested up to: 7.8.2
+WC tested up to: 8.2.0
 */
 
 defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: getdrip
 Tags: ecommerce, emailmarketing, marketingautomation, emailmarketingautomation, woocommerce, drip
 Requires at least: 4.6
-Tested up to: 6.2.2
-Stable tag: 1.1.6
+Tested up to: 6.3.1
+Stable tag: 1.1.7
 Requires PHP: 5.6
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -73,6 +73,10 @@ The philosophy behind this plugin is to do as little as possible in it, and as m
 = NEXT =
 
 * Your change here!
+
+= 1.1.7 =
+
+* Implement `drip_set_snippet_script_type` and `drip_set_snippet_script_additional_attributes` filters to add custom attributes in Drip's JS Snippet
 
 = 1.1.6 =
 

--- a/src/snippet.js.php
+++ b/src/snippet.js.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
+$script_type = apply_filters('drip_set_snippet_script_type', 'text/javascript');
+$script_additional_attributes = apply_filters('drip_set_snippet_script_additional_attributes', array());
 ?>
 
 <!-- Drip Code -->
@@ -17,8 +19,18 @@ defined( 'ABSPATH' ) || die( 'Executing outside of the WordPress context.' );
 
 	(function() {
 		var dc = document.createElement('script');
-		dc.type = 'text/javascript'; dc.async = true;
+		dc.type = '<?php echo esc_js( $script_type ); ?>'; 
+		dc.async = true;
 		dc.src = '//tag.getdrip.com/<?php echo esc_js( $account_id ); ?>.js';
+		<?php
+		if(is_array($script_additional_attributes)) {
+			foreach($script_additional_attributes as $attname => $attval) {
+				?>
+				dc.setAttribute("<?php echo esc_js( $attname ); ?>", "<?php echo esc_js( $attval ); ?>");
+				<?php
+			}
+		}
+		?>
 		var s = document.getElementsByTagName('script')[0];
 		s.parentNode.insertBefore(dc, s);
 	})();


### PR DESCRIPTION
## TL; DR

Implements two filters, `drip_set_snippet_script_type` and `drip_set_snippet_script_additional_attributes`, which allow devs to customize the Drip JavaScript snippet by adding custom attributes. 

## Context

These filters provide a way to modify the script type and add additional attributes to the Drip JS snippet, making it flexible and adaptable for various tracking and integration needs.

By implementing custom script type and attributes through these filters, developers can enhance the integration of the Drip JS snippet with cookie consent management platforms, where they normally have to set the script type to plain text before the visitor accepts the cookie policy and then it changes to javascript.